### PR TITLE
Plugin name casing frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | [Terraform IaC](terraform-iac/) | DevOps | Terraform and cloud Infrastructure as Code best practices |
 | [Solidity Web3](solidity-web3/) | Blockchain | Solidity smart contract security and development rules |
 
+## Utilities
+
+The `utils/` directory contains shared utilities for working with plugin data:
+
+**Plugin Display Names** (`utils/pluginDisplayName.ts`)
+
+When displaying plugin names in the UI (tiles/cards), use `getPluginDisplayName()` to get the proper display name:
+- If `displayName` is set in plugin.json, use it
+- Otherwise, convert the kebab-case name to title case (e.g., `hex-mcp` → `Hex Mcp`)
+
+For the `/add-plugin` command, use `getPluginCommandName()` to always get the original kebab-case name.
+
+```typescript
+import { getPluginDisplayName, getPluginCommandName } from '@cursor/plugins/utils';
+
+// For UI display (tiles, cards, etc.)
+const displayName = getPluginDisplayName(plugin); // 'Hex Mcp' or custom displayName
+
+// For commands like /add-plugin
+const commandName = getPluginCommandName(plugin); // 'hex-mcp'
+```
+
 ## Repository Structure
 
 This is a multi-plugin marketplace repository. The root `.cursor-plugin/marketplace.json` lists all plugins, and each plugin has its own manifest:
@@ -40,6 +62,10 @@ This is a multi-plugin marketplace repository. The root `.cursor-plugin/marketpl
 plugins/
 ├── .cursor-plugin/
 │   └── marketplace.json       # Marketplace manifest (lists all plugins)
+├── utils/                     # Shared utilities
+│   ├── index.ts               # Main exports
+│   ├── pluginDisplayName.ts   # Display name utilities
+│   └── pluginDisplayName.test.ts
 ├── plugin-name/
 │   ├── .cursor-plugin/
 │   │   └── plugin.json        # Per-plugin manifest

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,56 @@
+# Plugin Utilities
+
+Shared utilities for working with Cursor plugin data.
+
+## Plugin Display Names
+
+When displaying plugin names in the UI, there are two scenarios:
+
+### 1. Plugin Tiles/Cards (UI Display)
+
+Use `getPluginDisplayName()` which:
+- Returns `displayName` if set in plugin.json
+- Otherwise converts kebab-case name to title case
+
+```typescript
+import { getPluginDisplayName } from './pluginDisplayName';
+
+// Plugin without displayName
+getPluginDisplayName({ name: 'hex-mcp' }); // 'Hex Mcp'
+getPluginDisplayName({ name: 'amplitude-analysis' }); // 'Amplitude Analysis'
+getPluginDisplayName({ name: 'deploy-on-aws' }); // 'Deploy On Aws'
+
+// Plugin with displayName
+getPluginDisplayName({ name: 'hex-mcp', displayName: 'Hex' }); // 'Hex'
+```
+
+### 2. Commands (e.g., /add-plugin)
+
+Use `getPluginCommandName()` which always returns the original kebab-case name:
+
+```typescript
+import { getPluginCommandName } from './pluginDisplayName';
+
+getPluginCommandName({ name: 'hex-mcp' }); // 'hex-mcp'
+getPluginCommandName({ name: 'amplitude-analysis' }); // 'amplitude-analysis'
+```
+
+## Low-Level Utilities
+
+### `unkebab(kebabString: string): string`
+
+Converts a kebab-case string to title case:
+
+```typescript
+import { unkebab } from './pluginDisplayName';
+
+unkebab('hex-mcp'); // 'Hex Mcp'
+unkebab('amplitude-analysis'); // 'Amplitude Analysis'
+unkebab('sentry'); // 'Sentry'
+```
+
+## Usage Guidelines
+
+- **Plugin tiles/cards**: Always use `getPluginDisplayName()` for user-facing display
+- **/add-plugin command**: Always use `getPluginCommandName()` to preserve the exact plugin identifier
+- **Search/filtering**: Consider matching against both display name and command name for better UX

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Plugin utilities for Cursor
+ *
+ * These utilities provide consistent handling of plugin names across the UI.
+ */
+
+export { unkebab, getPluginDisplayName, getPluginCommandName } from './pluginDisplayName';

--- a/utils/pluginDisplayName.test.ts
+++ b/utils/pluginDisplayName.test.ts
@@ -1,0 +1,63 @@
+import { unkebab, getPluginDisplayName, getPluginCommandName } from './pluginDisplayName';
+
+describe('unkebab', () => {
+  it('converts kebab-case to title case', () => {
+    expect(unkebab('hex-mcp')).toBe('Hex Mcp');
+    expect(unkebab('amplitude-analysis')).toBe('Amplitude Analysis');
+    expect(unkebab('deploy-on-aws')).toBe('Deploy On Aws');
+    expect(unkebab('notion-workspace')).toBe('Notion Workspace');
+  });
+
+  it('handles single word without hyphens', () => {
+    expect(unkebab('sentry')).toBe('Sentry');
+    expect(unkebab('linear')).toBe('Linear');
+    expect(unkebab('cloudflare')).toBe('Cloudflare');
+    expect(unkebab('stripe')).toBe('Stripe');
+  });
+
+  it('handles words with numbers', () => {
+    expect(unkebab('context7-plugin')).toBe('Context7 Plugin');
+  });
+
+  it('handles empty string', () => {
+    expect(unkebab('')).toBe('');
+  });
+
+  it('handles multiple hyphens', () => {
+    expect(unkebab('nextjs-react-typescript')).toBe('Nextjs React Typescript');
+    expect(unkebab('deep-learning-python')).toBe('Deep Learning Python');
+  });
+});
+
+describe('getPluginDisplayName', () => {
+  it('returns displayName when set', () => {
+    expect(getPluginDisplayName({ name: 'hex-mcp', displayName: 'Hex' })).toBe('Hex');
+    expect(getPluginDisplayName({ name: 'amplitude-analysis', displayName: 'Amplitude' })).toBe('Amplitude');
+    expect(getPluginDisplayName({ name: 'prisma', displayName: 'Prisma ORM' })).toBe('Prisma ORM');
+  });
+
+  it('converts kebab-case name when displayName is not set', () => {
+    expect(getPluginDisplayName({ name: 'hex-mcp' })).toBe('Hex Mcp');
+    expect(getPluginDisplayName({ name: 'amplitude-analysis' })).toBe('Amplitude Analysis');
+    expect(getPluginDisplayName({ name: 'deploy-on-aws' })).toBe('Deploy On Aws');
+  });
+
+  it('handles single word names without hyphens', () => {
+    expect(getPluginDisplayName({ name: 'sentry' })).toBe('Sentry');
+    expect(getPluginDisplayName({ name: 'linear' })).toBe('Linear');
+    expect(getPluginDisplayName({ name: 'prisma' })).toBe('Prisma');
+  });
+
+  it('handles empty displayName as not set', () => {
+    expect(getPluginDisplayName({ name: 'hex-mcp', displayName: '' })).toBe('Hex Mcp');
+  });
+});
+
+describe('getPluginCommandName', () => {
+  it('always returns the original kebab-case name', () => {
+    expect(getPluginCommandName({ name: 'hex-mcp' })).toBe('hex-mcp');
+    expect(getPluginCommandName({ name: 'amplitude-analysis' })).toBe('amplitude-analysis');
+    expect(getPluginCommandName({ name: 'deploy-on-aws' })).toBe('deploy-on-aws');
+    expect(getPluginCommandName({ name: 'sentry' })).toBe('sentry');
+  });
+});

--- a/utils/pluginDisplayName.ts
+++ b/utils/pluginDisplayName.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility functions for formatting plugin display names
+ *
+ * When displaying plugin names in the UI (tiles/cards), if no displayName is set,
+ * the kebab-case plugin name should be converted to title case.
+ *
+ * For the /add-plugin command, keep the original kebab-case name.
+ */
+
+/**
+ * Converts a kebab-case string to title case
+ * @example
+ * unkebab('hex-mcp') // 'Hex Mcp'
+ * unkebab('amplitude-analysis') // 'Amplitude Analysis'
+ * unkebab('deploy-on-aws') // 'Deploy On Aws'
+ * unkebab('context7-plugin') // 'Context7 Plugin'
+ * unkebab('sentry') // 'Sentry'
+ */
+export function unkebab(kebabString: string): string {
+  if (!kebabString) {
+    return '';
+  }
+
+  return kebabString
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Gets the display name for a plugin
+ * If displayName is set, use it. Otherwise, convert the kebab-case name to title case.
+ *
+ * @param plugin - Plugin object with name and optional displayName
+ * @returns The display name to show in the UI
+ *
+ * @example
+ * getPluginDisplayName({ name: 'hex-mcp' }) // 'Hex Mcp'
+ * getPluginDisplayName({ name: 'hex-mcp', displayName: 'Hex' }) // 'Hex'
+ * getPluginDisplayName({ name: 'amplitude-analysis' }) // 'Amplitude Analysis'
+ */
+export function getPluginDisplayName(plugin: {
+  name: string;
+  displayName?: string;
+}): string {
+  if (plugin.displayName) {
+    return plugin.displayName;
+  }
+
+  return unkebab(plugin.name);
+}
+
+/**
+ * For the /add-plugin command, always use the original kebab-case name
+ * This function is provided for clarity and consistency
+ *
+ * @param plugin - Plugin object with name
+ * @returns The kebab-case name for use in commands
+ *
+ * @example
+ * getPluginCommandName({ name: 'hex-mcp' }) // 'hex-mcp'
+ * getPluginCommandName({ name: 'amplitude-analysis' }) // 'amplitude-analysis'
+ */
+export function getPluginCommandName(plugin: { name: string }): string {
+  return plugin.name;
+}


### PR DESCRIPTION
Add utility functions to format plugin names for UI display (unkebab-cased if no display name) and keep kebab-case for commands.

This PR introduces shared utilities for consistent plugin name formatting. The `getPluginDisplayName` function provides a user-friendly name for UI elements (using `displayName` if available, otherwise unkebab-casing the plugin name), while `getPluginCommandName` ensures the original kebab-case name is used for commands like `/add-plugin`. These utilities are intended for consumption by the frontend application.

---
[Slack Thread](https://anysphere.slack.com/archives/C0A758UQH42/p1770764116823909?thread_ts=1770764116.823909&cid=C0A758UQH42)

<p><a href="https://cursor.com/background-agent?bcId=bc-24f95b5a-e45e-5a17-82dc-faa67dacb5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24f95b5a-e45e-5a17-82dc-faa67dacb5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

