### PR TITLE
Add MCP browser tools requirement to web-browser plugin

### DIFF
--- a/web-browser/README.md
+++ b/web-browser/README.md
@@ -2,6 +2,10 @@
 
 Browser debugging: DevTools, network traces, and reproducible bug reports.
 
+## Requirements
+
+This plugin requires MCP browser tools (`browser_navigate`, `browser_snapshot`, `browser_network_requests`, etc.). These are included automatically in the Cursor desktop app. If you're using Cursor outside the desktop app, you'll need to install a browser MCP server separately.
+
 ## Installation
 
 ```bash

--- a/web-browser/agents/browser-debugger.md
+++ b/web-browser/agents/browser-debugger.md
@@ -6,7 +6,7 @@ model: fast
 
 # Browser debugger
 
-Browser debugging specialist using MCP browser tools for navigation, snapshots, and network traces.
+Browser debugging specialist using MCP browser tools for navigation, snapshots, and network traces. Requires MCP browser tools (included in the Cursor desktop app, or install a browser MCP server separately).
 
 ## Trigger
 


### PR DESCRIPTION
## Summary

- Adds a Requirements section to the web-browser plugin README noting that MCP browser tools are needed
- These tools are included in the Cursor desktop app, but need to be installed separately otherwise
- Adds the same note to the browser-debugger agent description


Made with [Cursor](https://cursor.com)