### PR TITLE
Cursor-pm plugin mcps

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -24,6 +24,11 @@
       "description": "Internal team workflows used by Cursor developers for CI, code review, and shipping."
     },
     {
+      "name": "cursor-pm",
+      "source": "cursor-pm",
+      "description": "Product management MCP bundle for Granola, Gong, Notion, and Slack."
+    },
+    {
       "name": "create-plugin",
       "source": "create-plugin",
       "description": "Scaffold and validate new Cursor plugins."

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | [Teaching](teaching/) | Utilities | Skill maps, practice plans, and feedback loops |
 | [Continual Learning](continual-learning/) | Developer Tools | Incremental transcript-driven AGENTS.md memory updates with high-signal bullet points |
 | [Cursor Team Kit](cursor-team-kit/) | Developer Tools | Internal-style workflows for CI, code review, shipping, and testing |
+| [Cursor PM](cursor-pm/) | Developer Tools | Product management MCP bundle for Granola, Gong, Notion, and Slack |
 | [Create Plugin](create-plugin/) | Developer Tools | Meta workflows for creating Cursor plugins with scaffolding and submission checks |
 | [Ralph Loop](ralph-loop/) | Developer Tools | Iterative self-referential AI loops using the Ralph Wiggum technique |
 

--- a/cursor-pm/.cursor-plugin/plugin.json
+++ b/cursor-pm/.cursor-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "cursor-pm",
+  "displayName": "Cursor PM",
+  "version": "1.0.0",
+  "description": "Product management MCP bundle for Granola, Gong, Notion, and Slack.",
+  "author": {
+    "name": "Cursor",
+    "email": "plugins@cursor.com"
+  },
+  "homepage": "https://github.com/cursor/plugins",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "keywords": [
+    "cursor-pm",
+    "product-management",
+    "mcp",
+    "granola",
+    "gong",
+    "notion",
+    "slack"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "mcp",
+    "product-management",
+    "productivity"
+  ],
+  "mcpServers": "./mcp.json"
+}

--- a/cursor-pm/LICENSE
+++ b/cursor-pm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cursor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cursor-pm/README.md
+++ b/cursor-pm/README.md
@@ -1,0 +1,33 @@
+# Cursor PM plugin
+
+MCP bundle for product workflows spanning meeting capture, call intelligence, docs, and team communication.
+
+## Installation
+
+```bash
+/add-plugin cursor-pm
+```
+
+## Components
+
+### MCP servers
+
+| MCP | Purpose |
+|:----|:--------|
+| `granola` | Access Granola meeting notes and transcripts |
+| `gong` | Pull Gong calls and transcript data for sales/customer context |
+| `notion` | Read and write Notion pages and databases |
+| `slack` | Search and post messages in Slack channels and threads |
+
+## Configuration
+
+This plugin exposes MCP server definitions in `mcp.json`. Set required environment variables before use:
+
+- `GONG_ACCESS_KEY`
+- `GONG_ACCESS_SECRET`
+- `SLACK_BOT_TOKEN`
+- `SLACK_TEAM_ID`
+
+## License
+
+MIT

--- a/cursor-pm/mcp.json
+++ b/cursor-pm/mcp.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://cursor.com/schemas/mcp.json",
+  "mcpServers": {
+    "granola": {
+      "url": "https://mcp.granola.ai/",
+      "description": "Granola MCP server for meeting notes and transcripts"
+    },
+    "gong": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "gong-mcp"
+      ],
+      "env": {
+        "GONG_ACCESS_KEY": "${GONG_ACCESS_KEY}",
+        "GONG_ACCESS_SECRET": "${GONG_ACCESS_SECRET}"
+      },
+      "description": "Gong MCP server for call recordings and transcript workflows"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "description": "Notion hosted MCP server for pages, databases, and docs"
+    },
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@anthropic/mcp-server-slack"
+      ],
+      "env": {
+        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "SLACK_TEAM_ID": "${SLACK_TEAM_ID}"
+      },
+      "description": "Slack MCP server for channel, message, and thread operations"
+    }
+  }
+}


### PR DESCRIPTION
Add a new `cursor-pm` plugin that includes Granola, Gong, Notion, and Slack MCP server definitions.

---
<p><a href="https://cursor.com/agents?id=bc-d2e5eea8-4f9b-4b03-b904-4e884929e3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2e5eea8-4f9b-4b03-b904-4e884929e3ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

