### PR TITLE
Plugin installation deeplink

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | [Create Plugin](create-plugin/) | Developer Tools | Meta workflows for creating Cursor plugins with scaffolding and submission checks |
 | [Ralph Loop](ralph-loop/) | Developer Tools | Iterative self-referential AI loops using the Ralph Wiggum technique |
 
+## Installation deeplink
+
+Install any plugin by name with:
+
+`/plugin/add?id=<plugin-name>`
+
+This deeplink maps to the same install flow as `/add-plugin <plugin-name>`.
+
 ## Repository structure
 
 This is a multi-plugin marketplace repository. The root `.cursor-plugin/marketplace.json` lists all plugins, and each plugin has its own manifest:

--- a/continual-learning/README.md
+++ b/continual-learning/README.md
@@ -15,9 +15,8 @@ It is designed to avoid noisy rewrites by:
 
 ## Installation
 
-```bash
-/add-plugin continual-learning
-```
+- Deeplink: [`/plugin/add?id=continual-learning`](/plugin/add?id=continual-learning)
+- Slash command: `/add-plugin continual-learning`
 
 ## How it works
 

--- a/create-plugin/README.md
+++ b/create-plugin/README.md
@@ -4,9 +4,8 @@ Meta workflows for creating Cursor plugins that are marketplace-ready.
 
 ## Installation
 
-```bash
-/add-plugin create-plugin
-```
+- Deeplink: [`/plugin/add?id=create-plugin`](/plugin/add?id=create-plugin)
+- Slash command: `/add-plugin create-plugin`
 
 ## Components
 

--- a/cursor-team-kit/README.md
+++ b/cursor-team-kit/README.md
@@ -4,9 +4,8 @@ Internal-style workflows for CI, code review, shipping, and test reliability.
 
 ## Installation
 
-```bash
-/add-plugin cursor-team-kit
-```
+- Deeplink: [`/plugin/add?id=cursor-team-kit`](/plugin/add?id=cursor-team-kit)
+- Slash command: `/add-plugin cursor-team-kit`
 
 ## Components
 

--- a/ralph-loop/README.md
+++ b/ralph-loop/README.md
@@ -8,9 +8,8 @@ Two hooks drive the loop. An `afterAgentResponse` hook watches each response for
 
 ## Installation
 
-```
-/add-plugin ralph-loop
-```
+- Deeplink: [`/plugin/add?id=ralph-loop`](/plugin/add?id=ralph-loop)
+- Slash command: `/add-plugin ralph-loop`
 
 ## Quick start
 

--- a/teaching/README.md
+++ b/teaching/README.md
@@ -4,9 +4,8 @@ Teaching workflows: skill mapping, practice plans, and feedback loops.
 
 ## Installation
 
-```bash
-/add-plugin teaching
-```
+- Deeplink: [`/plugin/add?id=teaching`](/plugin/add?id=teaching)
+- Slash command: `/add-plugin teaching`
 
 ## Components
 


### PR DESCRIPTION
Add `/plugin/add?id=<name>` deeplink to plugin installation documentation to enable direct plugin installation by name.

This PR updates plugin READMEs to document a new `/plugin/add?id=<name>` deeplink for installing plugins. This repository serves as a plugin catalog, so the changes are limited to updating installation instructions to include the new deeplink format alongside the existing `/add-plugin <name>` command.

---
[Slack Thread](https://anysphere.slack.com/archives/C08GVHK6H17/p1772064828119179?thread_ts=1772064828.119179&cid=C08GVHK6H17)

<p><a href="https://cursor.com/agents/bc-a4c0fe57-1115-5fba-8780-ca4d3568b387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4c0fe57-1115-5fba-8780-ca4d3568b387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

