### PR TITLE
fix(continual-learning): Resolve path issue for locating hook target files.

### DIFF
--- a/continual-learning/hooks/hooks.json
+++ b/continual-learning/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "stop": [
       {
-        "command": "bun run ./hooks/continual-learning-stop.ts --trial"
+        "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/continual-learning-stop.ts --trial"
       }
     ]
   }


### PR DESCRIPTION
### Related Issues

Fixes #31 

### Background

I encountered the same issue described in #31 after installation: hook target files could not be located by bun.

To figure out what happened, I modified the command in `hooks.json` to print the current working directory:

```json
{
  "version": 1,
  "hooks": {
    "stop": [
      {
         "command": "echo '{\"pwd\": \"'$PWD'\"}'"
      }
    ]
  }
}
```

The output revealed that the working directory points to the folder currently open in Cursor (instead of the plugin directory) — this is why bun failed to find the target files.

### Changes Made

This commit fixes the path issue by replacing the root path with `${CLAUDE_PLUGIN_ROOT}`.

### Test

This fix is only verified on my WSL environment.
