### PR TITLE
Add review of centrally managed settings for marketplace plugins

### DIFF
--- a/team-plugin-central-settings.md
+++ b/team-plugin-central-settings.md
@@ -1,0 +1,638 @@
+# Team-managed plugin settings for Cursor Marketplace plugins
+
+This document summarizes a review of the plugins currently surfaced by the Cursor Marketplace page and proposes the sets of configuration that should be managed centrally when a team enables plugins.
+
+Review date: 2026-03-24
+
+## Scope reviewed
+
+The marketplace page currently exposes 72 plugin records. At a high level, the catalog is dominated by:
+
+- 58 plugins with skills
+- 55 plugins with MCP servers
+- 24 plugins with rules
+- 17 plugins with commands
+- 8 plugins with hooks
+
+Curated marketplace categories represented on the page:
+
+- Productivity: 18
+- Data & Analytics: 17
+- Infrastructure: 15
+- Agent Orchestration: 9
+- Payments: 3
+- Featured: 4
+
+This matters because most team governance needs to focus on MCP access, skill/rule behavior, secrets, and write-capable actions rather than just install/uninstall.
+
+## Bottom line
+
+When setting up plugins for a team, the central admin surface should not be "one giant per-plugin blob." It should be a stable set of shared configuration groups that can be applied consistently across plugins:
+
+1. Distribution and lifecycle
+2. Identity, authentication, and secrets
+3. Authorization and write controls
+4. Resource and workspace targeting
+5. Data governance and compliance
+6. MCP runtime and network policy
+7. Rule, skill, agent, command, and hook policy
+8. Automation and workflow defaults
+9. Observability, audit, and incident handling
+10. Cost, rate limits, and quota controls
+11. Versioning and change management
+12. Per-category plugin presets
+
+Those are the settings sets that should be centrally managed. Individual developers can still choose local preferences inside the safe boundary the team defines.
+
+## Recommended central settings model
+
+### 1) Distribution and lifecycle
+
+These settings apply to every plugin, regardless of vendor.
+
+Manage centrally:
+
+- Whether the plugin is allowed at all
+- Required vs optional installation
+- Which distribution groups get the plugin
+- User-level vs project-level install expectation
+- Approved plugin version or update channel
+- Rollout stage: pilot, default-on, restricted, deprecated
+- Allowed platforms: desktop only, cloud agents, both
+- Review owner for the plugin
+- Revalidation cadence after plugin updates
+
+Why this is central:
+
+- Cursor team marketplaces already support required vs optional plugins and group-based distribution.
+- Teams need a consistent way to roll out plugins gradually and avoid every engineer self-selecting privileged integrations.
+
+### 2) Identity, authentication, and secrets
+
+This is the most common central settings area for MCP-backed plugins.
+
+Manage centrally:
+
+- Auth method: OAuth, API key, service account, hosted MCP auth, local credential
+- Credential ownership model: user credential vs shared team credential vs environment credential
+- Secret source: 1Password, vault, cloud secret manager, env var injection
+- Required secret names and mapping into MCP env vars
+- Rotation policy and expiry handling
+- Whether personal tokens are allowed
+- Whether break-glass credentials exist
+- IdP/SCIM group mapping for access entitlement
+- Region- or tenant-specific auth endpoints
+
+Why this is central:
+
+- Slack, Linear, GitLab, Datadog, AWS, Stripe, Postman, PagerDuty, PlanetScale, Box, Notion, and similar plugins are only useful after authenticated binding to a real workspace/account.
+- Teams need one approved secret path instead of every plugin inventing its own token story.
+
+### 3) Authorization and write controls
+
+Many plugins are not just read-only. They can create issues, send messages, deploy services, change incidents, or modify billing-related resources.
+
+Manage centrally:
+
+- Read-only vs read-write mode
+- Whether destructive actions are allowed
+- Whether production actions are allowed
+- Allowed action classes, for example:
+  - read/search only
+  - comment/update only
+  - create resources
+  - deploy/publish
+  - delete/destructive
+- Approval requirements for sensitive actions
+- Dry-run requirement for mutating workflows
+- Human confirmation requirements before send/post/deploy/merge
+- Repo or environment gates for automations
+
+Why this is central:
+
+- Slack can send messages
+- GitLab and Atlassian can mutate tickets or merge-request state
+- Render, AWS, Cloudflare, and Vercel can change infrastructure
+- PagerDuty can affect incident operations
+- Stripe, Circle, Phantom Connect, and eToro operate in financially sensitive domains
+
+If a team only centralizes one policy beyond installation, it should be this one.
+
+### 4) Resource and workspace targeting
+
+Most plugins need a default target boundary so the agent knows which org, team, project, workspace, account, or environment it should act against.
+
+Manage centrally:
+
+- Organization/workspace ID
+- Team/project defaults
+- Allowed repositories or services
+- Environment defaults: dev, staging, prod
+- Region/site selection
+- Account/subscription/tenant selection
+- Dataset/index/database defaults
+- Namespace, folder, board, or collection scoping
+- Resource allowlists and denylists
+
+Examples:
+
+- Slack: workspace, channels, allowed posting targets
+- Linear/Jira/Atlassian: workspace, team, project, workflow states
+- Datadog/Sentry/Grafana: org, services, environments, saved dashboards
+- AWS/Cloudflare/Vercel/Render: account, project, environment, region
+- Databricks/Snowflake/ClickHouse/Supabase/Prisma/Postgres/Cosmos DB: account, database, catalog, schema, branch
+- Box/Notion/Miro/Figma/Webflow/Wix: workspace/site/folder/board/file scope
+
+### 5) Data governance and compliance
+
+A large portion of the marketplace touches internal knowledge, production telemetry, customer data, support queues, code, financial records, or incident data.
+
+Manage centrally:
+
+- Data classification allowed for the plugin
+- Whether PII, PHI, finance, or customer-content access is allowed
+- Redaction requirements before tool invocation
+- Whether prompts/results may include raw production data
+- Log retention and transcript retention requirements
+- Allowed data export behavior
+- Region/data residency constraints
+- External sharing restrictions
+- Audit event retention requirements
+
+Why this is central:
+
+- Glean, Slack, Box, Notion, Plain, PostHog, Pendo, Amplitude, Datadog, Snowflake, and similar plugins often surface sensitive content.
+- Team policy should determine safe data handling once, not plugin by plugin.
+
+### 6) MCP runtime and network policy
+
+Because 55 marketplace plugins include MCP servers, this deserves its own first-class settings group.
+
+Manage centrally:
+
+- Whether the MCP server is enabled
+- Hosted MCP vs local command-based MCP preference
+- Approved command, args, and env templates for local MCPs
+- Allowed outbound hosts/domains
+- Network egress restrictions
+- Proxy configuration
+- Startup timeout and request timeout
+- Retry policy
+- Concurrency limit
+- Whether the MCP is available in cloud agents, local IDE only, or both
+- Health-check and failure-handling behavior
+
+Why this is central:
+
+- Even when two plugins solve similar problems, the operational risk often sits in the MCP runtime and network path, not the prompt text.
+- This is especially important for infrastructure, database, and enterprise SaaS plugins.
+
+### 7) Rule, skill, agent, command, and hook policy
+
+Marketplace plugins are not only connectors; they also change agent behavior through skills, rules, commands, and hooks.
+
+Manage centrally:
+
+- Which plugin components are enabled:
+  - MCP servers
+  - skills
+  - rules
+  - commands
+  - agents
+  - hooks
+- For rules:
+  - Always / Agent decides / Manual mode
+  - File globs or scope
+  - Conflict precedence with existing team rules
+- For skills:
+  - Available to all users or only certain groups
+  - Auto-discoverable vs manual-only invocation
+- For commands:
+  - Who may run them
+  - Which repos/projects they apply to
+- For hooks:
+  - Whether hooks are allowed at all
+  - Which hook events are permitted
+  - Which shell commands/scripts are approved
+
+Why this is central:
+
+- Skills and rules are the dominant non-MCP components in the marketplace.
+- Hooks are comparatively rare but high impact because they can run scripts automatically.
+
+### 8) Automation and workflow defaults
+
+Some plugins are most valuable when used inside recurring workflows rather than ad hoc chat.
+
+Manage centrally:
+
+- Which workflows are approved
+- Schedule or event triggers
+- Default prompt templates
+- Escalation destinations
+- Notification channels
+- Retry and backoff behavior
+- Safety checks before external actions
+- Required linked context, for example repo, incident, ticket, environment
+- Whether automations may open PRs, post comments, or page humans
+
+Examples:
+
+- Datadog + PagerDuty incident investigation
+- Slack + bug triage workflows
+- GitLab/Atlassian/Linear issue management
+- Render/Vercel/AWS deploy helpers
+- Postman/API validation workflows
+
+### 9) Observability, audit, and incident handling
+
+Teams will want a consistent trail for who enabled a plugin, what it accessed, and which mutations it made.
+
+Manage centrally:
+
+- Audit logging required or optional
+- Log sink destination
+- Request/response redaction policy
+- Change attribution model: human identity vs shared bot identity
+- Alerting on failed auth, denied actions, or high-risk mutations
+- Incident response owner if a plugin misbehaves
+- Break-glass disable switch
+
+Why this is central:
+
+- A plugin that can page PagerDuty, send Slack messages, create Stripe resources, or touch infrastructure should be observable like any other privileged automation.
+
+### 10) Cost, rate limits, and quota controls
+
+Some plugins call billed APIs or operate against metered systems.
+
+Manage centrally:
+
+- API budget owner
+- Per-user or per-team quota
+- Concurrency limit
+- Rate-limit backoff defaults
+- Whether expensive operations are allowed automatically
+- High-cost capability allowlists, for example:
+  - large analytics queries
+  - web crawling
+  - browser automation
+  - production deploys
+  - code scans across many repos
+
+Examples:
+
+- Tavily, Firecrawl, Parallel, Browserbase, Browserstack, Datadog, Snowflake, Postman, Stripe, and cloud/infrastructure plugins all have meaningful cost or quota exposure.
+
+### 11) Versioning and change management
+
+Plugin behavior can change even when the core team does nothing, because vendors update plugin contents and MCP behavior.
+
+Manage centrally:
+
+- Approved version or commit pin
+- Auto-update vs manual promotion
+- Changelog review requirement
+- Security review requirement for major changes
+- Rollback procedure
+- Owner sign-off for new scopes or write actions
+
+Why this is central:
+
+- Skills, rules, hooks, and MCP definitions are all behavior-changing artifacts. Teams need a promotion path similar to internal tooling.
+
+### 12) Per-category plugin presets
+
+Beyond the universal settings, teams should centralize a small set of category-specific presets.
+
+#### Productivity and collaboration plugins
+
+Examples reviewed:
+
+- Slack
+- Linear
+- Atlassian
+- GitLab
+- Box
+- Notion
+- Monday.com
+- Figma
+- Miro
+- Webflow
+- Wix
+- Sanity
+- LaunchDarkly
+- tldraw
+
+Central settings to standardize:
+
+- Workspace/team/project mapping
+- Read vs write permissions
+- Allowed posting/commenting destinations
+- Allowed issue/project state transitions
+- Publishing permissions
+- Content visibility and document scope
+- Human-approval requirement for outbound communication
+
+#### Infrastructure and operations plugins
+
+Examples reviewed:
+
+- AWS
+- Cloudflare
+- Vercel
+- Render
+- Datadog
+- PagerDuty
+- Sentry
+- JFrog
+- PlanetScale
+- Neon Postgres
+- Convex
+- Clerk
+- Browserstack
+
+Central settings to standardize:
+
+- Account/project/environment bindings
+- Production-change restrictions
+- Deploy approval gates
+- Incident-write permissions
+- Allowed services and regions
+- Environment separation rules
+- On-call and alerting destinations
+
+#### Data and analytics plugins
+
+Examples reviewed:
+
+- Amplitude
+- Pendo
+- PostHog
+- Databricks
+- Snowflake
+- ClickHouse
+- Azure Cosmos DB
+- Supabase
+- Prisma
+- Postman
+- Braintrust
+- Hex
+- Hugging Face
+- Omni
+
+Central settings to standardize:
+
+- Data source selection
+- Catalog/schema/database scope
+- Query safety mode
+- Allowed writeback operations
+- Data sensitivity tier
+- Maximum query breadth/cost
+- Saved workspace/project defaults
+
+#### Security, secrets, and code scanning plugins
+
+Examples reviewed:
+
+- 1Password
+- Snyk
+- Semgrep
+- Endor Labs
+- Cisco ThousandEyes
+
+Central settings to standardize:
+
+- Credential source of truth
+- Scan scope
+- Remediation authority
+- False-positive handling
+- Network visibility scope
+- Secret access approval rules
+
+#### Payments and financial plugins
+
+Examples reviewed:
+
+- Stripe
+- Circle
+- Phantom Connect
+- eToro
+
+Central settings to standardize:
+
+- Sandbox vs production default
+- Allowed transaction classes
+- Mutating-action approvals
+- Wallet/account/workspace binding
+- Audit retention
+- Financial-data handling policy
+
+#### Agent orchestration and runtime plugins
+
+Examples reviewed:
+
+- Runlayer
+- Firetiger
+- Compound Engineering
+- Context7
+- Parallel
+- Superpowers
+- Browserbase Browse
+- Create Plugin
+- Continual Learning
+- Cursor Team Kit
+
+Central settings to standardize:
+
+- Which orchestration features are enabled
+- Whether third-party agents may run automatically
+- Tooling and shell restrictions
+- Transcript retention
+- Hook allowance
+- Safety policy inheritance from the base team setup
+
+## What should be centrally managed vs locally adjustable
+
+### Central
+
+- Plugin allow/deny
+- Required vs optional
+- Group assignment
+- Auth method and secret source
+- Workspace/account/project/environment targets
+- Read/write/destructive permissions
+- Allowed component types
+- Hook allowance
+- Production access
+- Compliance classification
+- Audit requirements
+- Version/update policy
+- Budgets and quotas
+
+### Local or team-within-team adjustable
+
+- Personal notification preferences
+- Manual skill invocation choices
+- Optional plugin install decisions for optional plugins
+- Personal saved views or dashboards, if policy allows
+- Non-sensitive local convenience defaults
+
+## Proposed admin-facing schema
+
+This is the configuration shape a team marketplace setup flow should aim to collect:
+
+```yaml
+pluginPolicy:
+  distribution:
+    state: required | optional | blocked
+    groups: []
+    scope: project | user | both
+    rolloutStage: pilot | default | restricted | deprecated
+  auth:
+    mode: oauth | apiKey | serviceAccount | hostedMcp
+    credentialOwner: user | team | environment
+    secretSource: 1password | vault | env | cloud-secret-manager
+    allowPersonalTokens: false
+  access:
+    mode: readOnly | limitedWrite | fullWrite
+    allowProduction: false
+    destructiveActions: denied | approval | allowed
+    approvalRequiredFor: [send_message, deploy, delete, financial_write]
+  targets:
+    org: ""
+    workspace: ""
+    project: ""
+    environments: [dev, staging]
+    allowlist: []
+  governance:
+    dataClassifications: [internal]
+    allowSensitiveData: false
+    redactResponses: true
+    auditLogging: required
+  runtime:
+    enableMcp: true
+    enableSkills: true
+    enableRules: review
+    enableCommands: false
+    enableHooks: false
+    cloudAgentSupport: allowed
+    allowedHosts: []
+  automation:
+    approvedWorkflows: []
+    dryRunByDefault: true
+    notificationDestinations: []
+  operations:
+    owner: ""
+    budgetOwner: ""
+    updateChannel: pinned
+    rollbackContact: ""
+```
+
+## Practical setup flow for a team plugin
+
+If this were turned into a setup wizard, the admin flow should ask for settings in this order:
+
+1. Who gets the plugin?
+2. Is it required or optional?
+3. How does it authenticate?
+4. Which workspace/account/environment should it target?
+5. Is it read-only, limited-write, or full-write?
+6. Can it touch production or sensitive data?
+7. Which plugin components are enabled?
+8. Are hooks and commands allowed?
+9. What audits, logs, and approvals are required?
+10. How are updates promoted and rolled back?
+
+That sequence matches the actual risk profile of the current marketplace better than asking users to configure vendor-specific fields first.
+
+## Reviewed plugin inventory
+
+Plugins visible in the marketplace page payload during this review:
+
+- 1Password
+- Amplitude
+- Atlassian
+- Azure Cosmos DB
+- Box
+- Braintrust
+- Browserbase Browse
+- Browserstack
+- Circle
+- Cisco ThousandEyes
+- Clerk
+- ClickHouse
+- Cloudflare
+- Compound Engineering
+- Context7
+- Continual Learning
+- Convex
+- Create Plugin
+- Cursor Team Kit
+- Databricks
+- Datadog
+- AWS
+- elastic-docs
+- Endor Labs
+- eToro
+- Figma
+- Firecrawl
+- Firetiger
+- Browserbase Functions
+- GitLab
+- Glean
+- Grafana Labs
+- Hex
+- Hugging Face
+- JFrog
+- Langfuse
+- LaunchDarkly
+- Linear
+- Meta Reality Labs
+- Miro
+- Monday.com
+- Neon Postgres
+- Notion
+- Omni
+- PagerDuty
+- Parallel
+- Pendo
+- Phantom Connect
+- Plain
+- PlanetScale
+- PostHog
+- Postman
+- Prisma
+- Redis
+- Render
+- Runlayer
+- Sanity
+- Semgrep
+- Sentry
+- Slack
+- Snowflake
+- Snyk
+- Stripe
+- Supabase
+- Superpowers
+- Svelte
+- Tavily
+- tldraw
+- Vercel
+- Webflow
+- Wix
+- Zapier
+
+## Recommendation
+
+For a team marketplace or team plugin setup flow, the central admin model should be based on reusable policy groups rather than per-plugin bespoke forms. The strongest default policy stack for the current marketplace is:
+
+- group-based distribution
+- centralized secrets and auth
+- explicit read/write approval tiers
+- fixed workspace/account/environment targeting
+- MCP runtime controls
+- component-level enablement for skills/rules/commands/hooks
+- audit and update governance
+
+That model covers the repeated needs across collaboration, infrastructure, analytics, security, payments, and orchestration plugins without forcing teams to rebuild the same policy logic for every new marketplace integration.

--- a/team-plugin-custom-settings.mock.json
+++ b/team-plugin-custom-settings.mock.json
@@ -1,0 +1,1331 @@
+{
+  "version": 1,
+  "generatedAt": "2026-03-25",
+  "description": "Mock team-level plugin settings file for marketplace plugins that likely need custom setup beyond generic install toggles.",
+  "decisionRule": "A plugin is marked as requiring custom settings when team setup likely needs one or more of teamwide authentication, workspace or tenant binding, region or environment selection, scoped write permissions, secret injection, or runtime controls beyond generic enablement.",
+  "genericModalDefaults": {
+    "accessPermissions": "view",
+    "preferredModel": "gpt-5.4-high-fast",
+    "teamSettings": {
+      "enabled": false,
+      "region": "global",
+      "teamwideAuthentication": {
+        "mode": "none",
+        "connectionStatus": "not_configured"
+      }
+    }
+  },
+  "profiles": {
+    "collaborationWorkspace": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "atlassian",
+        "gitlab",
+        "glean",
+        "launchdarkly",
+        "linear",
+        "monday.com",
+        "plain",
+        "slack",
+        "zapier"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.workspaceId",
+        "teamSettings.defaultTeamIds",
+        "teamSettings.allowedReadActions",
+        "teamSettings.allowedWriteActions",
+        "teamSettings.approvalPolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "edit",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "eu-north-1",
+          "teamwideAuthentication": {
+            "mode": "oauth",
+            "connectionStatus": "connected",
+            "connectionRef": "acme-shared-oauth"
+          },
+          "workspaceId": "acme-main",
+          "defaultTeamIds": [
+            "ENG",
+            "PLATFORM"
+          ],
+          "allowedReadActions": [
+            "search",
+            "read",
+            "list"
+          ],
+          "allowedWriteActions": [
+            "comment",
+            "create_issue",
+            "update_issue"
+          ],
+          "approvalPolicy": {
+            "requireApprovalFor": [
+              "close_issue",
+              "change_priority",
+              "send_message"
+            ]
+          }
+        }
+      }
+    },
+    "designAndContentWorkspace": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "box",
+        "figma",
+        "miro",
+        "notion-workspace",
+        "sanity",
+        "tldraw",
+        "webflow",
+        "wix"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.workspaceId",
+        "teamSettings.defaultContentScopes",
+        "teamSettings.publishPolicy",
+        "teamSettings.allowedWriteActions"
+      ],
+      "mockSettings": {
+        "accessPermissions": "edit",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "us-east-1",
+          "teamwideAuthentication": {
+            "mode": "oauth",
+            "connectionStatus": "connected",
+            "connectionRef": "acme-design-oauth"
+          },
+          "workspaceId": "acme-design",
+          "defaultContentScopes": [
+            "design-system",
+            "marketing-site",
+            "product-docs"
+          ],
+          "allowedWriteActions": [
+            "create_draft",
+            "update_draft",
+            "comment"
+          ],
+          "publishPolicy": {
+            "allowPublish": false,
+            "approvalRequiredFor": [
+              "publish",
+              "delete_asset"
+            ]
+          }
+        }
+      }
+    },
+    "observabilityAndIncidentResponse": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "cisco-thousandeyes",
+        "datadog",
+        "grafana-assistant",
+        "pagerduty",
+        "sentry"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.siteOrOrg",
+        "teamSettings.defaultServices",
+        "teamSettings.defaultEnvironments",
+        "teamSettings.allowedWriteActions",
+        "teamSettings.incidentPolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "edit",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "eu-west-1",
+          "teamwideAuthentication": {
+            "mode": "apiKey",
+            "connectionStatus": "connected",
+            "secretRef": "vault://observability/shared-token"
+          },
+          "siteOrOrg": "acme-observability",
+          "defaultServices": [
+            "api",
+            "worker",
+            "web"
+          ],
+          "defaultEnvironments": [
+            "staging",
+            "prod"
+          ],
+          "allowedWriteActions": [
+            "comment_on_incident",
+            "create_dashboard"
+          ],
+          "incidentPolicy": {
+            "allowAck": false,
+            "allowResolve": false,
+            "notifyChannel": "#incident-triage"
+          }
+        }
+      }
+    },
+    "infrastructureAndDeployments": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "browserstack",
+        "clerk",
+        "cloudflare",
+        "convex",
+        "deploy-on-aws",
+        "jfrog",
+        "meta-quest-agentic-tools",
+        "neon-postgres",
+        "planetscale",
+        "render",
+        "vercel"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.accountId",
+        "teamSettings.defaultProjectIds",
+        "teamSettings.defaultEnvironments",
+        "teamSettings.allowedRegions",
+        "teamSettings.deployPolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "admin",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "us-east-1",
+          "teamwideAuthentication": {
+            "mode": "serviceAccount",
+            "connectionStatus": "connected",
+            "secretRef": "vault://infra/deploy-bot"
+          },
+          "accountId": "acme-platform",
+          "defaultProjectIds": [
+            "web-app",
+            "backend-api"
+          ],
+          "defaultEnvironments": [
+            "dev",
+            "staging"
+          ],
+          "allowedRegions": [
+            "us-east-1",
+            "eu-west-1"
+          ],
+          "deployPolicy": {
+            "allowProduction": false,
+            "requireApprovalFor": [
+              "deploy_prod",
+              "rotate_secret",
+              "delete_resource"
+            ]
+          }
+        }
+      }
+    },
+    "databaseAndAnalytics": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "amplitude",
+        "azure-cosmosdb",
+        "braintrust",
+        "clickhouse-cursor-plugin",
+        "databricks-skills",
+        "hex",
+        "huggingface-skills",
+        "langfuse",
+        "omni-analytics",
+        "pendo-analytics",
+        "posthog",
+        "postman",
+        "prisma",
+        "snowflake-cursor-plugin",
+        "supabase"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.accountOrWorkspaceId",
+        "teamSettings.defaultDatasets",
+        "teamSettings.defaultEnvironments",
+        "teamSettings.querySafetyMode",
+        "teamSettings.maxQueryCost"
+      ],
+      "mockSettings": {
+        "accessPermissions": "view",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "us-east-1",
+          "teamwideAuthentication": {
+            "mode": "apiKey",
+            "connectionStatus": "connected",
+            "secretRef": "vault://data/shared-token"
+          },
+          "accountOrWorkspaceId": "acme-data",
+          "defaultDatasets": [
+            "analytics_prod",
+            "product_events"
+          ],
+          "defaultEnvironments": [
+            "staging"
+          ],
+          "querySafetyMode": "read_only_by_default",
+          "maxQueryCost": "medium",
+          "writebackPolicy": {
+            "allowSchemaChanges": false,
+            "allowDataMutation": false
+          }
+        }
+      }
+    },
+    "developerDatabasesAndAPIPlatforms": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "browserbase-functions",
+        "clerk",
+        "databricks-skills",
+        "neon-postgres",
+        "planetscale",
+        "postman",
+        "prisma",
+        "supabase"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.defaultProjectIds",
+        "teamSettings.defaultDatabaseOrApiScope",
+        "teamSettings.environmentBindings",
+        "teamSettings.writePolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "edit",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "us-west-2",
+          "teamwideAuthentication": {
+            "mode": "serviceAccount",
+            "connectionStatus": "connected",
+            "secretRef": "vault://platform/devtools-bot"
+          },
+          "defaultProjectIds": [
+            "app-core",
+            "growth-api"
+          ],
+          "defaultDatabaseOrApiScope": "staging",
+          "environmentBindings": {
+            "development": "dev",
+            "preview": "staging"
+          },
+          "writePolicy": {
+            "allowBranchChanges": true,
+            "allowProductionWrites": false
+          }
+        }
+      }
+    },
+    "securityAndSecrets": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "1password",
+        "endorlabs",
+        "semgrep-plugin",
+        "snyk-secure-development"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.orgId",
+        "teamSettings.scanScope",
+        "teamSettings.secretAccessPolicy",
+        "teamSettings.remediationPolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "admin",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "global",
+          "teamwideAuthentication": {
+            "mode": "serviceAccount",
+            "connectionStatus": "connected",
+            "secretRef": "vault://security/scanner-bot"
+          },
+          "orgId": "acme-security",
+          "scanScope": [
+            "current_repo",
+            "dependencies"
+          ],
+          "secretAccessPolicy": {
+            "allowReadSecrets": false,
+            "allowReferenceSecrets": true
+          },
+          "remediationPolicy": {
+            "allowOpenPRs": true,
+            "allowAutoMerge": false
+          }
+        }
+      }
+    },
+    "paymentsAndFinancialSystems": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "circle",
+        "etoro",
+        "phantom-connect",
+        "stripe"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.accountId",
+        "teamSettings.mode",
+        "teamSettings.allowedWriteActions",
+        "teamSettings.approvalPolicy",
+        "teamSettings.auditRetentionDays"
+      ],
+      "mockSettings": {
+        "accessPermissions": "admin",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "us-east-1",
+          "teamwideAuthentication": {
+            "mode": "apiKey",
+            "connectionStatus": "connected",
+            "secretRef": "vault://finance/shared-token"
+          },
+          "accountId": "acme-sandbox",
+          "mode": "sandbox",
+          "allowedWriteActions": [
+            "create_test_resource",
+            "generate_checkout_link"
+          ],
+          "approvalPolicy": {
+            "requireApprovalFor": [
+              "production_charge",
+              "wallet_transfer",
+              "trade_execution"
+            ]
+          },
+          "auditRetentionDays": 365
+        }
+      }
+    },
+    "researchAndWebAutomation": {
+      "customSettingsLevel": "definite",
+      "usedBy": [
+        "browse",
+        "context7-plugin",
+        "firecrawl",
+        "parallel",
+        "tavily"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.allowedDomains",
+        "teamSettings.maxCrawlDepth",
+        "teamSettings.capturePolicy",
+        "teamSettings.rateLimitTier"
+      ],
+      "mockSettings": {
+        "accessPermissions": "edit",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "global",
+          "teamwideAuthentication": {
+            "mode": "apiKey",
+            "connectionStatus": "connected",
+            "secretRef": "vault://research/crawler-token"
+          },
+          "allowedDomains": [
+            "docs.acme.dev",
+            "developer.vendor.com"
+          ],
+          "maxCrawlDepth": 3,
+          "capturePolicy": {
+            "allowScreenshots": true,
+            "allowAuthenticatedBrowsing": false
+          },
+          "rateLimitTier": "standard"
+        }
+      }
+    },
+    "pluginRuntimeAndAutomation": {
+      "customSettingsLevel": "likely",
+      "usedBy": [
+        "compound-engineering",
+        "firetiger",
+        "runlayer"
+      ],
+      "requiredFields": [
+        "teamSettings.teamwideAuthentication",
+        "teamSettings.allowedRuntimeFeatures",
+        "teamSettings.allowedToolClasses",
+        "teamSettings.auditPolicy"
+      ],
+      "mockSettings": {
+        "accessPermissions": "admin",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "global",
+          "teamwideAuthentication": {
+            "mode": "oauth",
+            "connectionStatus": "connected",
+            "connectionRef": "acme-runtime-oauth"
+          },
+          "allowedRuntimeFeatures": [
+            "mcp",
+            "skills",
+            "commands"
+          ],
+          "allowedToolClasses": [
+            "read",
+            "write_repo",
+            "open_pr"
+          ],
+          "auditPolicy": {
+            "logAllMutations": true,
+            "retainDays": 90
+          }
+        }
+      }
+    },
+    "minimalGenericOnly": {
+      "customSettingsLevel": "minimal",
+      "usedBy": [
+        "continual-learning",
+        "create-plugin",
+        "cursor-team-kit",
+        "elastic-docs",
+        "redis-development",
+        "superpowers",
+        "svelte"
+      ],
+      "requiredFields": [],
+      "mockSettings": {
+        "accessPermissions": "view",
+        "preferredModel": "gpt-5.4-high-fast",
+        "teamSettings": {
+          "enabled": true,
+          "region": "global",
+          "teamwideAuthentication": {
+            "mode": "none",
+            "connectionStatus": "not_required"
+          }
+        }
+      }
+    }
+  },
+  "pluginDecisions": {
+    "1password": {
+      "displayName": "1Password",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "securityAndSecrets",
+      "reasons": [
+        "teamwide_auth",
+        "secret_access_policy",
+        "org_scope"
+      ]
+    },
+    "amplitude": {
+      "displayName": "Amplitude",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "analytics_data_scope",
+        "query_cost_controls"
+      ]
+    },
+    "atlassian": {
+      "displayName": "Atlassian",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "team_scope",
+        "ticket_write_actions"
+      ]
+    },
+    "azure-cosmosdb": {
+      "displayName": "Azure Cosmos DB",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "database_account_binding",
+        "credential_injection",
+        "query_scope"
+      ]
+    },
+    "box": {
+      "displayName": "Box",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "content_scope",
+        "write_permissions"
+      ]
+    },
+    "braintrust": {
+      "displayName": "Braintrust",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "credential_injection",
+        "project_scope"
+      ]
+    },
+    "browse": {
+      "displayName": "Browserbase Browse",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "researchAndWebAutomation",
+      "reasons": [
+        "credential_injection",
+        "domain_allowlist",
+        "automation_limits"
+      ]
+    },
+    "browserstack": {
+      "displayName": "Browserstack",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "account_binding",
+        "environment_scope",
+        "runtime_limits"
+      ]
+    },
+    "circle": {
+      "displayName": "Circle",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "paymentsAndFinancialSystems",
+      "reasons": [
+        "financial_account_binding",
+        "sandbox_vs_production",
+        "mutating_action_approval"
+      ]
+    },
+    "cisco-thousandeyes": {
+      "displayName": "Cisco ThousandEyes",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "observabilityAndIncidentResponse",
+      "reasons": [
+        "org_binding",
+        "network_visibility_scope",
+        "credential_injection"
+      ]
+    },
+    "clerk": {
+      "displayName": "Clerk",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "instance_binding",
+        "environment_scope",
+        "secret_injection"
+      ]
+    },
+    "clickhouse-cursor-plugin": {
+      "displayName": "ClickHouse",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "database_binding",
+        "query_scope",
+        "credential_injection"
+      ]
+    },
+    "cloudflare": {
+      "displayName": "Cloudflare",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "account_binding",
+        "region_and_zone_scope",
+        "deploy_permissions"
+      ]
+    },
+    "compound-engineering": {
+      "displayName": "Compound Engineering",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "likely",
+      "profile": "pluginRuntimeAndAutomation",
+      "reasons": [
+        "runtime_permissions",
+        "tooling_scope",
+        "automation_controls"
+      ]
+    },
+    "context7-plugin": {
+      "displayName": "Context7",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "researchAndWebAutomation",
+      "reasons": [
+        "api_or_runtime_binding",
+        "domain_scope",
+        "request_limits"
+      ]
+    },
+    "continual-learning": {
+      "displayName": "Continual Learning",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "local_workflow_only"
+      ]
+    },
+    "convex": {
+      "displayName": "Convex",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "project_binding",
+        "environment_scope",
+        "deploy_permissions"
+      ]
+    },
+    "create-plugin": {
+      "displayName": "Create Plugin",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "local_workflow_only"
+      ]
+    },
+    "cursor-team-kit": {
+      "displayName": "Cursor Team Kit",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "local_workflow_only"
+      ]
+    },
+    "databricks-skills": {
+      "displayName": "Databricks",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "catalog_scope",
+        "credential_injection"
+      ]
+    },
+    "datadog": {
+      "displayName": "Datadog",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "observabilityAndIncidentResponse",
+      "reasons": [
+        "site_selection",
+        "service_scope",
+        "incident_permissions"
+      ]
+    },
+    "deploy-on-aws": {
+      "displayName": "AWS",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "account_binding",
+        "region_selection",
+        "deploy_permissions"
+      ]
+    },
+    "elastic-docs": {
+      "displayName": "elastic-docs",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "likely_docs_only"
+      ]
+    },
+    "endorlabs": {
+      "displayName": "Endor Labs",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "securityAndSecrets",
+      "reasons": [
+        "org_binding",
+        "scanner_credentials",
+        "remediation_policy"
+      ]
+    },
+    "etoro": {
+      "displayName": "eToro",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "paymentsAndFinancialSystems",
+      "reasons": [
+        "financial_account_binding",
+        "sandbox_vs_production",
+        "mutating_action_approval"
+      ]
+    },
+    "figma": {
+      "displayName": "Figma",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "file_scope",
+        "content_write_permissions"
+      ]
+    },
+    "firecrawl": {
+      "displayName": "Firecrawl",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "researchAndWebAutomation",
+      "reasons": [
+        "api_credentials",
+        "domain_allowlist",
+        "crawl_limits"
+      ]
+    },
+    "firetiger": {
+      "displayName": "Firetiger",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "likely",
+      "profile": "pluginRuntimeAndAutomation",
+      "reasons": [
+        "runtime_permissions",
+        "tooling_scope",
+        "automation_controls"
+      ]
+    },
+    "browserbase-functions": {
+      "displayName": "Browserbase Functions",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "developerDatabasesAndAPIPlatforms",
+      "reasons": [
+        "account_binding",
+        "environment_scope",
+        "write_permissions"
+      ]
+    },
+    "gitlab": {
+      "displayName": "GitLab",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "repo_scope",
+        "merge_request_write_actions"
+      ]
+    },
+    "glean": {
+      "displayName": "Glean",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "search_scope",
+        "identity_mapping"
+      ]
+    },
+    "grafana-assistant": {
+      "displayName": "Grafana Labs",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "observabilityAndIncidentResponse",
+      "reasons": [
+        "org_binding",
+        "dashboard_scope",
+        "credential_injection"
+      ]
+    },
+    "hex": {
+      "displayName": "Hex",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "project_scope",
+        "credential_injection"
+      ]
+    },
+    "huggingface-skills": {
+      "displayName": "Hugging Face",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "token_management",
+        "resource_scope",
+        "cost_controls"
+      ]
+    },
+    "jfrog": {
+      "displayName": "JFrog",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "org_binding",
+        "artifact_scope",
+        "write_permissions"
+      ]
+    },
+    "langfuse": {
+      "displayName": "Langfuse",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "project_binding",
+        "credential_injection",
+        "data_scope"
+      ]
+    },
+    "launchdarkly": {
+      "displayName": "LaunchDarkly",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "project_binding",
+        "environment_scope",
+        "flag_write_permissions"
+      ]
+    },
+    "linear": {
+      "displayName": "Linear",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "teamwide_auth",
+        "workspace_binding",
+        "issue_write_actions"
+      ]
+    },
+    "meta-quest-agentic-tools": {
+      "displayName": "Meta Reality Labs",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "device_or_org_binding",
+        "runtime_scope",
+        "credential_injection"
+      ]
+    },
+    "miro": {
+      "displayName": "Miro",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "board_scope",
+        "content_write_permissions"
+      ]
+    },
+    "monday.com": {
+      "displayName": "Monday.com",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "board_scope",
+        "write_permissions"
+      ]
+    },
+    "neon-postgres": {
+      "displayName": "Neon Postgres",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "account_binding",
+        "database_branch_scope",
+        "credential_injection"
+      ]
+    },
+    "notion-workspace": {
+      "displayName": "Notion",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "page_scope",
+        "write_permissions"
+      ]
+    },
+    "omni-analytics": {
+      "displayName": "Omni",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "model_scope",
+        "credential_injection"
+      ]
+    },
+    "pagerduty": {
+      "displayName": "PagerDuty",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "observabilityAndIncidentResponse",
+      "reasons": [
+        "account_binding",
+        "service_scope",
+        "incident_write_permissions"
+      ]
+    },
+    "parallel": {
+      "displayName": "Parallel",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "researchAndWebAutomation",
+      "reasons": [
+        "api_credentials",
+        "crawl_or_search_limits",
+        "domain_scope"
+      ]
+    },
+    "pendo-analytics": {
+      "displayName": "Pendo",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "workspace_binding",
+        "analytics_scope",
+        "credential_injection"
+      ]
+    },
+    "phantom-connect": {
+      "displayName": "Phantom Connect",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "paymentsAndFinancialSystems",
+      "reasons": [
+        "wallet_binding",
+        "sandbox_vs_production",
+        "mutating_action_approval"
+      ]
+    },
+    "plain": {
+      "displayName": "Plain",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "support_queue_scope",
+        "write_permissions"
+      ]
+    },
+    "planetscale": {
+      "displayName": "PlanetScale",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "org_binding",
+        "database_scope",
+        "credential_injection"
+      ]
+    },
+    "posthog": {
+      "displayName": "PostHog",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "project_binding",
+        "analytics_scope",
+        "writeback_controls"
+      ]
+    },
+    "postman": {
+      "displayName": "Postman",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "developerDatabasesAndAPIPlatforms",
+      "reasons": [
+        "workspace_binding",
+        "api_scope",
+        "write_permissions"
+      ]
+    },
+    "prisma": {
+      "displayName": "Prisma",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "developerDatabasesAndAPIPlatforms",
+      "reasons": [
+        "database_binding",
+        "environment_scope",
+        "migration_permissions"
+      ]
+    },
+    "redis-development": {
+      "displayName": "Redis",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "likely_guidance_only"
+      ]
+    },
+    "render": {
+      "displayName": "Render",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "account_binding",
+        "environment_scope",
+        "deploy_permissions"
+      ]
+    },
+    "runlayer": {
+      "displayName": "Runlayer",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "likely",
+      "profile": "pluginRuntimeAndAutomation",
+      "reasons": [
+        "runtime_permissions",
+        "secret_protection_policies",
+        "audit_controls"
+      ]
+    },
+    "sanity": {
+      "displayName": "Sanity",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "dataset_binding",
+        "content_scope",
+        "publish_permissions"
+      ]
+    },
+    "semgrep-plugin": {
+      "displayName": "Semgrep",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "securityAndSecrets",
+      "reasons": [
+        "org_binding",
+        "scan_scope",
+        "remediation_policy"
+      ]
+    },
+    "sentry": {
+      "displayName": "Sentry",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "observabilityAndIncidentResponse",
+      "reasons": [
+        "org_binding",
+        "project_scope",
+        "incident_write_permissions"
+      ]
+    },
+    "slack": {
+      "displayName": "Slack",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "channel_allowlist",
+        "send_message_permissions"
+      ]
+    },
+    "snowflake-cursor-plugin": {
+      "displayName": "Snowflake",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "databaseAndAnalytics",
+      "reasons": [
+        "account_binding",
+        "warehouse_scope",
+        "query_cost_controls"
+      ]
+    },
+    "snyk-secure-development": {
+      "displayName": "Snyk",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "securityAndSecrets",
+      "reasons": [
+        "org_binding",
+        "scan_scope",
+        "remediation_policy"
+      ]
+    },
+    "stripe": {
+      "displayName": "Stripe",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "paymentsAndFinancialSystems",
+      "reasons": [
+        "account_binding",
+        "sandbox_vs_production",
+        "financial_write_permissions"
+      ]
+    },
+    "supabase": {
+      "displayName": "Supabase",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "developerDatabasesAndAPIPlatforms",
+      "reasons": [
+        "project_binding",
+        "database_scope",
+        "environment_permissions"
+      ]
+    },
+    "superpowers": {
+      "displayName": "Superpowers",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "local_workflow_only"
+      ]
+    },
+    "svelte": {
+      "displayName": "Svelte",
+      "requiresCustomSettings": false,
+      "customSettingsLevel": "minimal",
+      "profile": "minimalGenericOnly",
+      "reasons": [
+        "framework_guidance_only"
+      ]
+    },
+    "tavily": {
+      "displayName": "Tavily",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "researchAndWebAutomation",
+      "reasons": [
+        "api_credentials",
+        "domain_scope",
+        "usage_limits"
+      ]
+    },
+    "tldraw": {
+      "displayName": "tldraw",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "file_scope",
+        "write_permissions"
+      ]
+    },
+    "vercel": {
+      "displayName": "Vercel",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "infrastructureAndDeployments",
+      "reasons": [
+        "team_binding",
+        "project_scope",
+        "deploy_permissions"
+      ]
+    },
+    "webflow": {
+      "displayName": "Webflow",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "site_scope",
+        "publish_permissions"
+      ]
+    },
+    "wix": {
+      "displayName": "Wix",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "designAndContentWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "site_scope",
+        "publish_permissions"
+      ]
+    },
+    "zapier": {
+      "displayName": "Zapier",
+      "requiresCustomSettings": true,
+      "customSettingsLevel": "definite",
+      "profile": "collaborationWorkspace",
+      "reasons": [
+        "workspace_binding",
+        "action_scope",
+        "automation_permissions"
+      ]
+    }
+  },
+  "unclassifiedNeedsManualReview": [
+    {
+      "plugin": "browserbase-functions",
+      "reason": "May fit either developer platform or research automation depending on the implementation details."
+    },
+    {
+      "plugin": "databricks-skills",
+      "reason": "Listed as skills-only on the marketplace page, but likely still needs workspace and auth settings."
+    },
+    {
+      "plugin": "elastic-docs",
+      "reason": "Likely docs-only, but can be promoted to custom settings if the MCP needs org-specific endpoints."
+    },
+    {
+      "plugin": "langfuse",
+      "reason": "Grouped under analytics because it usually needs project keys and environment binding."
+    },
+    {
+      "plugin": "meta-quest-agentic-tools",
+      "reason": "Exact setup may depend on whether device bridge credentials and lab infrastructure are centrally managed."
+    }
+  ]
+}

--- a/top-partner-plugin-settings.spec.json
+++ b/top-partner-plugin-settings.spec.json
@@ -1,0 +1,601 @@
+{
+  "version": 1,
+  "generatedAt": "2026-03-25",
+  "description": "Focused product spec and mock persisted config for the most team-relevant marketplace partners: Datadog, Linear, AWS, Stripe, Figma, and Notion.",
+  "goals": [
+    "Define which settings should be surfaced in a team plugin setup modal for top partners.",
+    "Separate centrally managed team policy from per-user connection state.",
+    "Use one shared JSON structure with plugin-specific sections only where needed."
+  ],
+  "designPrinciples": [
+    "Prefer a shared config envelope across plugins.",
+    "Only use team-managed authentication for plugins that naturally map to shared service credentials or IAM role assumptions.",
+    "Prefer user-level OAuth for SaaS tools where actions should be attributable to an individual user.",
+    "Keep scope and write permissions explicit.",
+    "Model UI fields that are likely to appear in a setup modal separately from persisted auth secrets."
+  ],
+  "authModelPolicy": {
+    "sharedTeamAuthPreferred": [
+      {
+        "plugin": "datadog",
+        "reason": "Teams often want a shared service account or scoped API/app key pair, plus a single Datadog site/region and read-vs-write policy."
+      },
+      {
+        "plugin": "deploy-on-aws",
+        "reason": "AWS setup is naturally team-managed via IAM roles, named profiles, environment restrictions, and deploy guardrails."
+      }
+    ],
+    "userOAuthPreferred": [
+      {
+        "plugin": "linear",
+        "reason": "Issue/project actions should be attributable to the connected user, while the team controls allowed project/team scopes."
+      },
+      {
+        "plugin": "stripe",
+        "reason": "Stripe officially supports OAuth MCP sessions and separates access by sandbox/live mode; user attribution is important for sensitive actions."
+      },
+      {
+        "plugin": "figma",
+        "reason": "Design actions are usually tied to an individual designer or engineer account; team setup should mainly constrain team/project/file scope."
+      },
+      {
+        "plugin": "notion-workspace",
+        "reason": "Workspace access and page/database actions are best tied to each user's Notion permissions, with team defaults for allowed spaces and writable databases."
+      }
+    ]
+  },
+  "sharedConfigShape": {
+    "fields": {
+      "pluginId": "Marketplace plugin slug",
+      "displayName": "Human-readable plugin name",
+      "enabled": "Whether the plugin is enabled for the team",
+      "installation": {
+        "required": "Whether installation is required or optional",
+        "scope": "Where the plugin is expected to run: user, project, or both"
+      },
+      "access": {
+        "defaultPermissionTier": "Default permission UI selection: view, edit, or admin",
+        "allowWrite": "Whether writes are generally allowed",
+        "allowSensitiveWrite": "Whether high-risk writes are allowed at all"
+      },
+      "auth": {
+        "mode": "shared_service_account, iam_role, or user_oauth",
+        "teamConnectionRequired": "Whether admin must set up a team-level connection before use",
+        "userConnectionAllowed": "Whether users can connect their own accounts",
+        "credentialRef": "Reference to centrally stored secret or role config when applicable"
+      },
+      "scope": {
+        "regionOrSite": "Vendor-specific site/region selection if required",
+        "workspaceId": "Top-level workspace/account/team identifier where applicable",
+        "allowedScopes": "Plugin-specific allowlist, such as projects, teams, files, pages, or environments"
+      },
+      "guardrails": {
+        "approvalRequiredFor": "Mutating actions requiring explicit approval",
+        "blockedActions": "Actions disallowed entirely",
+        "auditMode": "Required auditing level"
+      },
+      "ui": {
+        "setupFields": "Fields that the setup modal should actually render"
+      }
+    }
+  },
+  "plugins": {
+    "datadog": {
+      "pluginId": "datadog",
+      "displayName": "Datadog",
+      "enabled": true,
+      "installation": {
+        "required": true,
+        "scope": "both"
+      },
+      "access": {
+        "defaultPermissionTier": "view",
+        "allowWrite": false,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "shared_service_account",
+        "teamConnectionRequired": true,
+        "userConnectionAllowed": true,
+        "credentialRef": "vault://observability/datadog-service-account",
+        "connectionDetails": {
+          "supportedMethods": [
+            "oauth",
+            "api_key_and_application_key"
+          ],
+          "preferredMethod": "api_key_and_application_key",
+          "notes": [
+            "Use a scoped Datadog service account for shared team setup when central control is desired.",
+            "User OAuth can remain supported for individual access, but the team policy should still define site and write capability."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": "app.datadoghq.eu",
+        "workspaceId": "acme-observability",
+        "allowedScopes": {
+          "toolsets": [
+            "core",
+            "visualizations"
+          ],
+          "services": [
+            "web",
+            "api",
+            "worker"
+          ],
+          "environments": [
+            "staging",
+            "prod"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "create_monitor",
+          "mute_monitor",
+          "incident_write"
+        ],
+        "blockedActions": [
+          "org_settings_write"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "datadogSite",
+          "teamwideAuthenticationMethod",
+          "sharedCredentialConnection",
+          "allowedServices",
+          "allowedEnvironments",
+          "allowWrite",
+          "approvalPolicy"
+        ]
+      }
+    },
+    "linear": {
+      "pluginId": "linear",
+      "displayName": "Linear",
+      "enabled": true,
+      "installation": {
+        "required": true,
+        "scope": "user"
+      },
+      "access": {
+        "defaultPermissionTier": "edit",
+        "allowWrite": true,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "user_oauth",
+        "teamConnectionRequired": false,
+        "userConnectionAllowed": true,
+        "credentialRef": null,
+        "connectionDetails": {
+          "supportedMethods": [
+            "oauth",
+            "personal_api_key"
+          ],
+          "preferredMethod": "oauth",
+          "notes": [
+            "User-level OAuth is preferred so issue creation and updates are attributable to the connected user.",
+            "The team setup modal should not ask admins for a shared token by default."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": null,
+        "workspaceId": "acme-linear",
+        "allowedScopes": {
+          "teams": [
+            "ENG",
+            "PLATFORM"
+          ],
+          "projects": [
+            "Core Platform",
+            "Developer Experience"
+          ],
+          "allowedWriteActions": [
+            "create_issue",
+            "comment_issue",
+            "update_issue"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "close_issue",
+          "change_priority",
+          "change_workflow_state_outside_allowed_states"
+        ],
+        "blockedActions": [
+          "delete_project"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "allowedTeams",
+          "allowedProjects",
+          "allowedWorkflowStates",
+          "allowWrite",
+          "approvalPolicy",
+          "requireUserOAuth"
+        ]
+      }
+    },
+    "deploy-on-aws": {
+      "pluginId": "deploy-on-aws",
+      "displayName": "AWS",
+      "enabled": true,
+      "installation": {
+        "required": true,
+        "scope": "both"
+      },
+      "access": {
+        "defaultPermissionTier": "admin",
+        "allowWrite": true,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "iam_role",
+        "teamConnectionRequired": true,
+        "userConnectionAllowed": false,
+        "credentialRef": "aws://role/acme-cursor-deploy-role",
+        "connectionDetails": {
+          "supportedMethods": [
+            "iam_role",
+            "aws_profile",
+            "environment_credentials"
+          ],
+          "preferredMethod": "iam_role",
+          "notes": [
+            "Use a centrally managed IAM role or role chain rather than personal AWS credentials.",
+            "The setup should collect account, role, region allowlist, and environment restrictions."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": "us-east-1",
+        "workspaceId": "123456789012",
+        "allowedScopes": {
+          "accounts": [
+            "123456789012"
+          ],
+          "regions": [
+            "us-east-1",
+            "eu-west-1"
+          ],
+          "environments": [
+            "dev",
+            "staging"
+          ],
+          "deploymentTargets": [
+            "ecs",
+            "lambda",
+            "s3_cloudfront"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "deploy_prod",
+          "create_or_update_iam",
+          "delete_infrastructure",
+          "rotate_secret"
+        ],
+        "blockedActions": [
+          "deploy_to_unlisted_account",
+          "deploy_to_unlisted_region"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "awsAccountId",
+          "iamRoleArnOrName",
+          "allowedRegions",
+          "allowedEnvironments",
+          "deploymentTargets",
+          "allowWrite",
+          "allowProductionDeploys",
+          "approvalPolicy"
+        ]
+      }
+    },
+    "stripe": {
+      "pluginId": "stripe",
+      "displayName": "Stripe",
+      "enabled": true,
+      "installation": {
+        "required": false,
+        "scope": "user"
+      },
+      "access": {
+        "defaultPermissionTier": "view",
+        "allowWrite": false,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "user_oauth",
+        "teamConnectionRequired": false,
+        "userConnectionAllowed": true,
+        "credentialRef": null,
+        "connectionDetails": {
+          "supportedMethods": [
+            "oauth",
+            "restricted_api_key"
+          ],
+          "preferredMethod": "oauth",
+          "notes": [
+            "Stripe documents OAuth as the preferred connection mechanism for MCP clients.",
+            "The team policy should still specify whether sandbox-only access is required and which mutating actions are blocked."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": null,
+        "workspaceId": "acme-stripe",
+        "allowedScopes": {
+          "mode": "sandbox",
+          "allowedWriteActions": [
+            "create_customer",
+            "create_product",
+            "create_price",
+            "create_payment_link"
+          ],
+          "blockedWriteActions": [
+            "create_refund",
+            "cancel_subscription",
+            "production_charge"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "live_mode_write",
+          "refund",
+          "subscription_cancel"
+        ],
+        "blockedActions": [
+          "live_mode_write"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "mode",
+          "allowedWriteActions",
+          "blockedWriteActions",
+          "requireUserOAuth",
+          "approvalPolicy"
+        ]
+      }
+    },
+    "figma": {
+      "pluginId": "figma",
+      "displayName": "Figma",
+      "enabled": true,
+      "installation": {
+        "required": false,
+        "scope": "user"
+      },
+      "access": {
+        "defaultPermissionTier": "edit",
+        "allowWrite": true,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "user_oauth",
+        "teamConnectionRequired": false,
+        "userConnectionAllowed": true,
+        "credentialRef": null,
+        "connectionDetails": {
+          "supportedMethods": [
+            "oauth"
+          ],
+          "preferredMethod": "oauth",
+          "notes": [
+            "Figma likely needs user-level OAuth because file and comment actions map naturally to a user's Figma identity.",
+            "The team setup should constrain which team, projects, and files are expected defaults."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": null,
+        "workspaceId": "acme-design-team",
+        "allowedScopes": {
+          "projects": [
+            "Design System",
+            "Product UI"
+          ],
+          "files": [
+            "UI Kit",
+            "App Shell"
+          ],
+          "allowedWriteActions": [
+            "create_file",
+            "create_comment",
+            "update_design_draft"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "modify_shared_library",
+          "publish_design_changes"
+        ],
+        "blockedActions": [
+          "delete_file"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "allowedProjects",
+          "defaultFiles",
+          "allowWrite",
+          "requireUserOAuth",
+          "approvalPolicy"
+        ]
+      }
+    },
+    "notion-workspace": {
+      "pluginId": "notion-workspace",
+      "displayName": "Notion",
+      "enabled": true,
+      "installation": {
+        "required": false,
+        "scope": "user"
+      },
+      "access": {
+        "defaultPermissionTier": "edit",
+        "allowWrite": true,
+        "allowSensitiveWrite": false
+      },
+      "auth": {
+        "mode": "user_oauth",
+        "teamConnectionRequired": false,
+        "userConnectionAllowed": true,
+        "credentialRef": null,
+        "connectionDetails": {
+          "supportedMethods": [
+            "oauth"
+          ],
+          "preferredMethod": "oauth",
+          "notes": [
+            "Notion workspace access is best aligned to each user's existing page and database permissions.",
+            "Team setup should mainly define the spaces, databases, and write patterns considered safe defaults."
+          ]
+        }
+      },
+      "scope": {
+        "regionOrSite": null,
+        "workspaceId": "acme-notion",
+        "allowedScopes": {
+          "parentPages": [
+            "Engineering",
+            "Product Specs"
+          ],
+          "databases": [
+            "Tasks",
+            "RFCs"
+          ],
+          "allowedWriteActions": [
+            "create_page",
+            "create_task",
+            "create_database_row",
+            "update_page"
+          ]
+        }
+      },
+      "guardrails": {
+        "approvalRequiredFor": [
+          "write_to_unlisted_database",
+          "bulk_update"
+        ],
+        "blockedActions": [
+          "delete_page",
+          "delete_database"
+        ],
+        "auditMode": "all_mutations"
+      },
+      "ui": {
+        "setupFields": [
+          "enabled",
+          "defaultPermissionTier",
+          "allowedParentPages",
+          "allowedDatabases",
+          "allowWrite",
+          "requireUserOAuth",
+          "approvalPolicy"
+        ]
+      }
+    }
+  },
+  "recommendedSetupModalSpec": {
+    "commonFields": [
+      {
+        "id": "enabled",
+        "label": "Enable for team",
+        "type": "boolean"
+      },
+      {
+        "id": "defaultPermissionTier",
+        "label": "Access permissions",
+        "type": "enum",
+        "options": [
+          "view",
+          "edit",
+          "admin"
+        ]
+      },
+      {
+        "id": "preferredModel",
+        "label": "Preferred model",
+        "type": "enum",
+        "options": [
+          "gpt-5.4-high-fast"
+        ]
+      }
+    ],
+    "pluginSpecificFields": {
+      "datadog": [
+        "datadogSite",
+        "teamwideAuthenticationMethod",
+        "sharedCredentialConnection",
+        "allowedServices",
+        "allowedEnvironments",
+        "allowWrite",
+        "approvalPolicy"
+      ],
+      "linear": [
+        "allowedTeams",
+        "allowedProjects",
+        "allowedWorkflowStates",
+        "allowWrite",
+        "requireUserOAuth",
+        "approvalPolicy"
+      ],
+      "deploy-on-aws": [
+        "awsAccountId",
+        "iamRoleArnOrName",
+        "allowedRegions",
+        "allowedEnvironments",
+        "deploymentTargets",
+        "allowProductionDeploys",
+        "approvalPolicy"
+      ],
+      "stripe": [
+        "mode",
+        "allowedWriteActions",
+        "blockedWriteActions",
+        "requireUserOAuth",
+        "approvalPolicy"
+      ],
+      "figma": [
+        "allowedProjects",
+        "defaultFiles",
+        "allowWrite",
+        "requireUserOAuth",
+        "approvalPolicy"
+      ],
+      "notion-workspace": [
+        "allowedParentPages",
+        "allowedDatabases",
+        "allowWrite",
+        "requireUserOAuth",
+        "approvalPolicy"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- review the current Cursor Marketplace plugin catalog and recurring component patterns
- document which plugin configuration surfaces should be managed centrally for team setup
- add a broad mock JSON file that flags which marketplace plugins likely require custom setup
- add a focused top-partner settings spec for Datadog, Linear, AWS, Stripe, Figma, and Notion with a clear shared-vs-user auth model and setup field recommendations

## Testing
- parsed `team-plugin-custom-settings.mock.json` with Python `json.loads` to verify valid JSON
- verified the broad mock file includes 72 plugin decisions and reusable profile groupings
- parsed `top-partner-plugin-settings.spec.json` with Python `json.loads`
- verified the focused spec contains 6 plugins with the expected auth split: shared team auth for Datadog and AWS, user OAuth for Linear, Stripe, Figma, and Notion

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df642c81-b8a3-424e-99c7-3b1b2e18a37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df642c81-b8a3-424e-99c7-3b1b2e18a37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

