### PR TITLE
Add AKF — The AI Native File Format

### DIFF
--- a/akf-trust-metadata/.cursor-plugin/plugin.json
+++ b/akf-trust-metadata/.cursor-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "akf-trust-metadata",
+  "displayName": "AKF — The AI Native File Format",
+  "version": "1.0.0",
+  "description": "EXIF for AI. Stamps every file agents generate with trust scores, source provenance, and compliance metadata. ~15 tokens of JSON that embed into 20+ formats.",
+  "author": {
+    "name": "HMAKT99",
+    "email": "akf@akf.dev"
+  },
+  "homepage": "https://akf.dev",
+  "repository": "https://github.com/HMAKT99/AKF",
+  "license": "MIT",
+  "keywords": [
+    "trust",
+    "metadata",
+    "provenance",
+    "compliance",
+    "ai-native",
+    "file-format",
+    "eu-ai-act",
+    "exif-for-ai"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "trust",
+    "provenance",
+    "compliance",
+    "ai-safety",
+    "developer-tools"
+  ],
+  "skills": "./skills/"
+}

--- a/akf-trust-metadata/LICENSE
+++ b/akf-trust-metadata/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HMAKT99
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/akf-trust-metadata/README.md
+++ b/akf-trust-metadata/README.md
@@ -1,0 +1,32 @@
+# AKF — The AI Native File Format
+
+EXIF for AI. Stamps every file your agents generate with trust scores, source provenance, and compliance metadata.
+
+## What it does
+
+When Cursor agents create or modify files, AKF stamps them with ~15 tokens of JSON carrying:
+- **Trust scores** (0–1) based on source tier
+- **Source provenance** — where the information came from
+- **Compliance metadata** — EU AI Act, SOX, HIPAA, NIST readiness
+
+The metadata embeds natively into 20+ formats — DOCX, PDF, images, Markdown, YAML, JSON, Python, TypeScript, Go, Rust, HTML — no sidecars.
+
+## Quick start
+
+```bash
+pip install akf
+akf stamp report.md --agent cursor --evidence "generated from user prompt"
+akf inspect report.md
+```
+
+## Why
+
+- **47% of developers** distrust AI-generated code (Cognition/Devin, 2026)
+- **EU AI Act Article 50** takes effect August 2, 2026 — AI content must carry transparency metadata
+- Every file agents generate should carry provenance
+
+## Links
+
+- [akf.dev](https://akf.dev)
+- [GitHub](https://github.com/HMAKT99/AKF)
+- [Demo](https://huggingface.co/spaces/HANAKT19/akf)

--- a/akf-trust-metadata/skills/akf-stamp/SKILL.md
+++ b/akf-trust-metadata/skills/akf-stamp/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: akf-stamp
+description: >-
+  Stamps files with AKF trust metadata — the AI native file format.
+  Use after creating or modifying any file to add trust scores, source
+  provenance, and compliance metadata. Use before modifying existing files
+  to check current trust context. Use when the user mentions trust,
+  provenance, compliance, EU AI Act, or metadata.
+---
+
+# AKF — The AI Native File Format
+
+Every photo has EXIF. Every song has ID3. AKF is the native metadata format for AI-generated content — ~15 tokens of JSON that embed trust scores, source provenance, and compliance data into 20+ file formats.
+
+## After creating or modifying files
+
+Stamp every file you create or modify with trust metadata:
+
+```bash
+akf stamp <file> --agent cursor --evidence "<what you did>"
+```
+
+Evidence should describe what you did:
+- `"generated from user prompt"` — new file from scratch
+- `"refactored existing code"` — modification
+- `"tests pass"` — after running tests
+- `"docs reviewed"` — documentation
+- `"bug fix, verified manually"` — fixes
+
+## Before modifying existing files
+
+Always check existing trust metadata first:
+
+```bash
+akf read <file>
+akf inspect <file>
+```
+
+This shows who last modified the file, their evidence, and the trust score. Preserve or update this context.
+
+## Classification
+
+Apply security labels based on file location:
+
+- `--label confidential` for files in `*/finance/*`, `*/secret/*`, `*/internal/*`
+- `--label public` for README, docs, examples, open-source files
+- Default is `internal`
+
+## Compliance auditing
+
+Check if files meet regulatory requirements:
+
+```bash
+akf audit <file> --regulation eu_ai_act    # EU AI Act Article 50
+akf audit <file> --regulation hipaa         # HIPAA
+akf audit <file> --regulation sox           # SOX
+akf audit <file> --regulation nist_ai       # NIST AI RMF
+```
+
+## Trust scoring
+
+Trust scores range from 0 to 1, based on source tier:
+
+| Tier | Score | Examples |
+|------|-------|----------|
+| T1 | 0.95 | SEC filings, court records, official APIs |
+| T2 | 0.85 | Reuters, peer-reviewed journals |
+| T3 | 0.70 | News articles, Wikipedia |
+| T4 | 0.50 | Blog posts, forums |
+| T5 | 0.30 | Unverified AI output |
+
+Human review promotes AI content from T5 (0.30) to T3+ (0.70+).
+
+## Install
+
+```bash
+pip install akf
+```
+
+## Links
+
+- Website: https://akf.dev
+- GitHub: https://github.com/HMAKT99/AKF
+- npm: `npm install akf-format`
+- Demo: https://huggingface.co/spaces/HANAKT19/akf


### PR DESCRIPTION
EXIF for AI. Stamps every file agents generate with trust scores, source provenance, and compliance metadata (~15 tokens of JSON, 20+ formats).

**Why Cursor needs this:**
- 47% of developers distrust AI-generated code (up from 31% in 2024)
- EU AI Act Article 50 takes effect August 2 — AI content must carry transparency metadata
- Every file Cursor agents generate should carry provenance

**What the plugin does:**
- Teaches agents to `akf stamp` files after creating/modifying them
- `akf read` before modifying shows existing trust context
- `akf audit --regulation eu_ai_act` for compliance checking

**Install:** `pip install akf`
**Docs:** https://akf.dev
**Demo:** https://huggingface.co/spaces/HANAKT19/akf