### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **content/configuration monorepo** of Cursor IDE plugins. There is no backend, database, or build step. Each top-level directory is a standalone plugin with its own `.cursor-plugin/plugin.json` manifest.
+
+### Validation (the main "build/test/lint" step)
+
+```bash
+npm install --no-save ajv ajv-formats
+node scripts/validate-plugins.mjs
+```
+
+This validates all plugin manifests (JSON) against schemas in `schemas/`. It is the only CI check (see `.github/workflows/validate-plugins.yml`). Node.js >= 20 is required.
+
+### Hooks testing
+
+- **continual-learning** stop hook requires **Bun**: `echo '{"conversation_id":"x","status":"completed","loop_count":0}' | bun run continual-learning/hooks/continual-learning-stop.ts`
+- **ralph-loop** hooks require **bash** and **jq** (both pre-installed). The stop hook expects a state file at `.cursor/ralph/scratchpad.md`; without it, it exits cleanly.
+
+### Caveats
+
+- There is no `package.json` in the repo. Dependencies (`ajv`, `ajv-formats`) are installed ephemerally with `npm install --no-save`. The resulting `node_modules/` is gitignored.
+- No lockfile exists; `npm install --no-save` always fetches the latest compatible versions, matching CI behavior.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with `## Cursor Cloud specific instructions` to document development environment setup for future cloud agents.

### What's included

- Validation command reference (`npm install --no-save ajv ajv-formats && node scripts/validate-plugins.mjs`)
- Hooks testing instructions for `continual-learning` (Bun) and `ralph-loop` (bash + jq)
- Caveats about the ephemeral dependency model (no `package.json`, no lockfile)

### Evidence of working environment

Validation output:
[validation_output.log](https://cursor.com/artifacts/c/art-a8145d99-426d-48a0-acda-351cee21e103)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19bd7130-829e-48ca-96d9-e401b899533a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19bd7130-829e-48ca-96d9-e401b899533a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

