### PR TITLE
feat: add Tempo payments plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -42,6 +42,11 @@
       "name": "cli-for-agent",
       "source": "cli-for-agent",
       "description": "Patterns for designing CLIs that coding agents can run reliably: flags, help with examples, pipelines, errors, idempotency, dry-run."
+    },
+    {
+      "name": "tempo",
+      "source": "tempo",
+      "description": "Tempo payments skill for integrating stablecoin payments and fee sponsorship."
     }
   ]
 }

--- a/tempo/.cursor-plugin/plugin.json
+++ b/tempo/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "tempo",
+  "version": "0.1.0",
+  "description": "Tempo payments integration helpers: skills for sending/accepting stablecoin payments, fee sponsorship, and reconciliation memos.",
+  "author": {
+    "name": "Cursor Community"
+  },
+  "license": "MIT",
+  "keywords": [
+    "tempo",
+    "payments",
+    "stablecoin",
+    "tip-20",
+    "memos",
+    "fee-sponsorship",
+    "typescript",
+    "node"
+  ]
+}
+

--- a/tempo/LICENSE
+++ b/tempo/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/tempo/README.md
+++ b/tempo/README.md
@@ -1,0 +1,10 @@
+# Tempo (Cursor plugin)
+
+Adds a payments-focused agent skill for integrating **Tempo stablecoin payments** in TypeScript/Node apps.
+
+## Components
+
+### Skills
+
+- `tempo-payments`: docs links + high-signal checklist for send/accept payments, memos, and fee sponsorship.
+

--- a/tempo/skills/tempo-payments/SKILL.md
+++ b/tempo/skills/tempo-payments/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: tempo-payments
+description: Integrate Tempo stablecoin payments (send/accept), TransferWithMemo reconciliation, and optional fee sponsorship in TypeScript/Node apps.
+---
+
+# Tempo Payments (TypeScript/Node)
+
+## Use these docs (Tempo)
+
+- Payments overview: `https://docs.tempo.xyz/guide/payments/`
+- Send a payment: `https://docs.tempo.xyz/guide/payments/send-a-payment/`
+- Accept + verify payments: `https://docs.tempo.xyz/guide/payments/accept-a-payment/`
+- Transfer memos (TransferWithMemo): `https://docs.tempo.xyz/guide/payments/transfer-memos/`
+- Sponsor user fees: `https://docs.tempo.xyz/guide/payments/sponsor-user-fees/`
+- Pay fees in any stablecoin: `https://docs.tempo.xyz/guide/payments/pay-fees-in-any-stablecoin/`
+
+## What to build in a “payments” section
+
+### Payment intent (server)
+
+Create a stable interface your UI can render and your backend can reconcile:
+- token address
+- recipient address
+- amount (base units)
+- memo / invoice id (prefer bytes32-compatible)
+- expiry (optional)
+
+### Accept & reconcile (server)
+
+Mark an invoice paid only after verifying onchain:
+- correct TIP-20 token
+- correct `to` address
+- correct amount (exact or \(\ge\) expected, depending on your policy)
+- correct memo (via `TransferWithMemo` when used)
+- finality rules per Tempo docs
+
+### Client integration
+
+Use Viem/Wagmi + Tempo guides to:
+- connect wallet/account
+- send TIP-20 transfer (with memo when you need reconciliation)
+- show receipt / paid state
+
+### Fee UX (optional)
+
+Choose one:
+- let users pay fees in stablecoins (no gas token)
+- sponsor fees (fee payer service) for gasless UX
+
+## Guardrails
+
+- Do not put secrets (emails, PII, API keys) in memos; memos are public.
+- Keep memo format deterministic and idempotent (e.g. `invoice:<id>` hashed to bytes32).
+- Do not hardcode RPC URLs/chain IDs in code unless Tempo docs recommend it; keep config per env.
+

--- a/tempo/skills/tempo-payments/SKILL.md
+++ b/tempo/skills/tempo-payments/SKILL.md
@@ -14,6 +14,16 @@ description: Integrate Tempo stablecoin payments (send/accept), TransferWithMemo
 - Sponsor user fees: `https://docs.tempo.xyz/guide/payments/sponsor-user-fees/`
 - Pay fees in any stablecoin: `https://docs.tempo.xyz/guide/payments/pay-fees-in-any-stablecoin/`
 
+## MPP (Machine Payments Protocol)
+
+If what you’re building is **paid API access** (HTTP `402` flows) rather than “send a transfer to an address”, use Tempo’s MPP docs:
+
+- Tempo MPP overview: `https://docs.tempo.xyz/guide/machine-payments/`
+
+If you’re exposing a paid **MCP tool/server**, the MPP MCP transport spec is here:
+
+- MPP MCP transport: `https://mpp.dev/protocol/transports/mcp`
+
 ## What to build in a “payments” section
 
 ### Payment intent (server)

--- a/tempo/skills/tempo-payments/SKILL.md
+++ b/tempo/skills/tempo-payments/SKILL.md
@@ -14,6 +14,10 @@ description: Integrate Tempo stablecoin payments (send/accept), TransferWithMemo
 - Sponsor user fees: `https://docs.tempo.xyz/guide/payments/sponsor-user-fees/`
 - Pay fees in any stablecoin: `https://docs.tempo.xyz/guide/payments/pay-fees-in-any-stablecoin/`
 
+## Tempo Wallet (agent setup)
+
+- Tempo Wallet skill: `https://tempo.xyz/SKILL.md`
+
 ## MPP (Machine Payments Protocol)
 
 If what you’re building is **paid API access** (HTTP `402` flows) rather than “send a transfer to an address”, use Tempo’s MPP docs:


### PR DESCRIPTION
Adds a new Tempo plugin with a payments-focused skill linking to Tempo send/accept flows, transfer memos, and fee sponsorship docs.

Made-with: Cursor