### PR TITLE
Add Not Human Search and AI Dev Jobs MCP plugins

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -52,6 +52,16 @@
       "name": "docs-canvas",
       "source": "docs-canvas",
       "description": "Render documentation — architecture notes, API references, runbooks, and codebase walkthroughs — as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references."
+    },
+    {
+      "name": "nothumansearch-mcp",
+      "source": "nothumansearch-mcp",
+      "description": "Search engine for AI agents. Find websites and APIs ranked by agentic readiness score (0-100). 8,600+ indexed sites with MCP, OpenAPI, and llms.txt detection."
+    },
+    {
+      "name": "aidevjobs-mcp",
+      "source": "aidevjobs-mcp",
+      "description": "Search curated AI/ML engineering jobs. Filter by skill, salary, workplace, and level. 5,400+ roles from 280+ companies."
     }
   ]
 }

--- a/aidevjobs-mcp/.cursor-plugin/plugin.json
+++ b/aidevjobs-mcp/.cursor-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "aidevjobs-mcp",
+  "displayName": "AI Dev Jobs",
+  "version": "1.2.0",
+  "description": "Search curated AI/ML engineering jobs. Filter by skill, salary, workplace, and level. 5,400+ roles from 280+ companies.",
+  "author": {
+    "name": "United Ideas",
+    "email": "unitedideas@gmail.com"
+  },
+  "publisher": "United Ideas",
+  "homepage": "https://aidevboard.com",
+  "repository": "https://github.com/unitedideas/aidevboard-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "jobs",
+    "ai-jobs",
+    "ml-jobs",
+    "career",
+    "hiring",
+    "engineering",
+    "job-search"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "mcp-server",
+    "jobs",
+    "ai-ml",
+    "career"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "aidevjobs": {
+      "url": "https://aidevboard.com/mcp"
+    }
+  }
+}

--- a/aidevjobs-mcp/CHANGELOG.md
+++ b/aidevjobs-mcp/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.2.0 (2026-04-16)
+- Added `match_jobs` tool for candidate-profile matching
+- 5,400+ jobs from 280+ companies
+- Published to official MCP registry as com.aidevboard/jobs
+
+## 1.1.0 (2026-04-12)
+- Added per_page pagination support
+- OpenAPI 3.0 spec at /openapi.yaml
+- Rate limiting with per-IP tracking
+
+## 1.0.0 (2026-03-01)
+- Initial release with search_jobs, get_job, list_companies, and get_stats
+- 55 ATS source scrapers
+- Daily automated job updates

--- a/aidevjobs-mcp/LICENSE
+++ b/aidevjobs-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 United Ideas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/aidevjobs-mcp/README.md
+++ b/aidevjobs-mcp/README.md
@@ -1,0 +1,45 @@
+# AI Dev Jobs MCP
+
+Specialized job board for AI/ML engineers. Search curated roles by skill, salary, workplace, and level.
+
+## What it does
+
+- **Job search**: Query 5,400+ curated AI/ML engineering roles from 280+ companies
+- **Filtering**: Filter by tag (pytorch, llm, mlops), workplace (remote, hybrid, onsite), level (junior, mid, senior, lead), and salary range
+- **Company listings**: Browse top AI/ML companies with role counts and average salaries
+- **Candidate matching**: Rank active jobs against a candidate profile with scored results
+- **Statistics**: Real-time index stats including total jobs, median salary, and new listings
+
+## 5 MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_jobs` | Search curated AI/ML roles by tag, workplace, level, salary, or keyword |
+| `get_job` | Fetch a full job posting by ID or slug |
+| `list_companies` | Top AI/ML companies hiring, with role counts and average salaries |
+| `get_stats` | Current index statistics: total jobs, companies, median salary, new this week |
+| `match_jobs` | Rank jobs against a candidate profile (skills, salary, workplace, level, location) |
+
+## Installation
+
+Install via the Cursor plugin marketplace:
+
+```
+/add-plugin aidevjobs-mcp
+```
+
+Or add the MCP server manually:
+
+```bash
+claude mcp add --transport http aidevjobs https://aidevboard.com/mcp
+```
+
+## No API key required
+
+All tools are free to use with no authentication.
+
+## Links
+
+- Website: [aidevboard.com](https://aidevboard.com)
+- GitHub: [github.com/unitedideas/aidevboard-mcp](https://github.com/unitedideas/aidevboard-mcp)
+- MCP Registry: [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)

--- a/aidevjobs-mcp/mcp.json
+++ b/aidevjobs-mcp/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "aidevjobs": {
+      "url": "https://aidevboard.com/mcp"
+    }
+  }
+}

--- a/aidevjobs-mcp/skills/match-candidate/SKILL.md
+++ b/aidevjobs-mcp/skills/match-candidate/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: match-candidate
+description: Rank AI/ML jobs against a candidate profile for personalized recommendations
+tools:
+  - aidevjobs.match_jobs
+  - aidevjobs.get_job
+  - aidevjobs.list_companies
+---
+
+# Match Jobs to a Candidate
+
+Use AI Dev Jobs to rank active positions against a candidate's skills, preferences, and experience level.
+
+## When to use
+
+- User describes their background and asks "what jobs would be a good fit?"
+- User wants personalized job recommendations based on their skills
+- User asks "which AI companies should I apply to?"
+- User wants to compare companies hiring for their skill set
+
+## Steps
+
+1. Gather the candidate's profile: skills, desired salary, workplace preference, level, and location
+2. Call `match_jobs` with the profile to get scored recommendations
+3. Call `get_job` on the top matches for full postings with apply links
+4. Call `list_companies` to show which top companies match their profile
+
+## Example
+
+"I'm a senior ML engineer skilled in PyTorch and LLMs, looking for remote work around $250k"
+
+```
+match_jobs(skills=["pytorch", "llm"], level="senior", workplace="remote", salary=250000)
+```

--- a/aidevjobs-mcp/skills/search-jobs/SKILL.md
+++ b/aidevjobs-mcp/skills/search-jobs/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: search-jobs
+description: Search curated AI/ML engineering jobs by skill, salary, workplace, or level
+tools:
+  - aidevjobs.search_jobs
+  - aidevjobs.get_job
+  - aidevjobs.get_stats
+---
+
+# Search AI/ML Jobs
+
+Use AI Dev Jobs to find curated engineering roles at top AI/ML companies.
+
+## When to use
+
+- User asks about AI/ML job openings or hiring companies
+- User wants to find remote AI engineering roles
+- User asks "who's hiring for LLM engineers?" or "find PyTorch jobs"
+- User wants salary data for AI/ML roles
+
+## Steps
+
+1. Call `search_jobs` with relevant filters (tag, workplace, level, salary range)
+2. Review results — each includes title, company, salary, location, and tags
+3. Call `get_job` on interesting listings for the full posting with apply link
+
+## Filters
+
+- `q` — keyword search (e.g. "LLM", "computer vision")
+- `tag` — skill tag (pytorch, tensorflow, llm, mlops, cv, nlp, rl, data-science)
+- `workplace` — remote, hybrid, onsite
+- `level` — junior, mid, senior, lead, principal
+- `min_salary` / `max_salary` — salary range filter
+- `company` — filter by company name
+
+## Example
+
+"Find remote senior LLM engineering jobs paying over $200k"
+
+```
+search_jobs(tag="llm", workplace="remote", level="senior", min_salary=200000)
+```

--- a/nothumansearch-mcp/.cursor-plugin/plugin.json
+++ b/nothumansearch-mcp/.cursor-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "nothumansearch-mcp",
+  "displayName": "Not Human Search",
+  "version": "1.4.0",
+  "description": "Search engine for AI agents. Find websites and APIs ranked by agentic readiness score (0-100). 8,600+ indexed sites with MCP, OpenAPI, and llms.txt detection.",
+  "author": {
+    "name": "United Ideas",
+    "email": "unitedideas@gmail.com"
+  },
+  "publisher": "United Ideas",
+  "homepage": "https://nothumansearch.ai",
+  "repository": "https://github.com/unitedideas/nothumansearch",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "ai-agents",
+    "search-engine",
+    "agentic",
+    "llms-txt",
+    "openapi",
+    "api-discovery",
+    "agent-tools"
+  ],
+  "category": "ai-tools",
+  "tags": [
+    "mcp-server",
+    "ai-agents",
+    "search",
+    "api-discovery"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "nothumansearch": {
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  }
+}

--- a/nothumansearch-mcp/CHANGELOG.md
+++ b/nothumansearch-mcp/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.4.0 (2026-04-16)
+- Added `verify_mcp` tool for live JSON-RPC probing of MCP endpoints
+- 8,600+ sites indexed with 494 MCP-verified via JSON-RPC probe
+- Expanded crawler API detection paths
+- Published to official MCP registry as ai.nothumansearch/search
+
+## 1.3.0 (2026-04-14)
+- Added `/monitor` endpoint for score-drop alerts
+- Rate limiting with per-IP tracking
+
+## 1.0.0 (2026-03-01)
+- Initial release with search, site details, submit, and stats tools
+- Agentic readiness scoring (0-100)
+- llms.txt, OpenAPI, MCP detection

--- a/nothumansearch-mcp/LICENSE
+++ b/nothumansearch-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 United Ideas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nothumansearch-mcp/README.md
+++ b/nothumansearch-mcp/README.md
@@ -1,0 +1,45 @@
+# Not Human Search MCP
+
+Search engine built for AI agents. Find websites and APIs ranked by agentic readiness score (0-100).
+
+## What it does
+
+- **Agent-ready search**: Query 8,600+ indexed sites by keyword, category, or minimum agentic score
+- **Readiness scoring**: Every site scored 0-100 based on MCP server, OpenAPI spec, llms.txt, structured API, and documentation quality
+- **Site details**: Get a full agentic readiness report for any domain
+- **Submit sites**: Add new sites for crawling and scoring
+- **Monitoring**: Subscribe to alerts when a domain's score drops
+
+## 5 MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_agents` | Search for agent-ready websites and APIs by keyword, category, or minimum score |
+| `get_site_details` | Get detailed agentic readiness report for a specific domain |
+| `submit_site` | Submit a new site for crawling and indexing |
+| `get_stats` | Get index statistics: total sites, average score, top category |
+| `register_monitor` | Subscribe to alerts when a domain's agentic readiness score drops |
+
+## Installation
+
+Install via the Cursor plugin marketplace:
+
+```
+/add-plugin nothumansearch-mcp
+```
+
+Or add the MCP server manually:
+
+```bash
+claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
+```
+
+## No API key required
+
+All tools are free to use with no authentication.
+
+## Links
+
+- Website: [nothumansearch.ai](https://nothumansearch.ai)
+- GitHub: [github.com/unitedideas/nothumansearch](https://github.com/unitedideas/nothumansearch)
+- MCP Registry: [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)

--- a/nothumansearch-mcp/mcp.json
+++ b/nothumansearch-mcp/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "nothumansearch": {
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  }
+}

--- a/nothumansearch-mcp/skills/score-site/SKILL.md
+++ b/nothumansearch-mcp/skills/score-site/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: score-site
+description: Get a detailed agentic readiness report for any domain and submit new sites for scoring
+tools:
+  - nothumansearch.get_site_details
+  - nothumansearch.submit_site
+  - nothumansearch.register_monitor
+---
+
+# Score a Site's Agent Readiness
+
+Get a detailed breakdown of how well a website supports AI agent integration.
+
+## When to use
+
+- User asks "is this site agent-ready?" or "can an AI use this API?"
+- User wants to check if a service has an MCP server, OpenAPI spec, or llms.txt
+- User wants to submit their own site for scoring
+- User wants to monitor a domain's readiness score over time
+
+## Steps
+
+1. Call `get_site_details` with the domain to get the full report
+2. If the domain is not indexed, call `submit_site` to queue it for crawling
+3. Optionally call `register_monitor` to get email alerts on score changes
+
+## Score breakdown
+
+The agentic readiness score (0-100) is based on:
+- MCP server presence and verification
+- OpenAPI/Swagger specification
+- llms.txt file
+- Structured API endpoints
+- Documentation quality
+- API key accessibility
+
+## Example
+
+"Check how agent-ready stripe.com is"
+
+```
+get_site_details(domain="stripe.com")
+```

--- a/nothumansearch-mcp/skills/search-agents/SKILL.md
+++ b/nothumansearch-mcp/skills/search-agents/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: search-agents
+description: Find agent-ready websites and APIs by keyword, category, or minimum agentic score
+tools:
+  - nothumansearch.search_agents
+  - nothumansearch.get_site_details
+  - nothumansearch.get_stats
+---
+
+# Search Agent-Ready Sites
+
+Use Not Human Search to find websites and APIs that are ready for AI agent integration.
+
+## When to use
+
+- User needs to find APIs or tools for an AI agent to use
+- User asks "which sites have MCP servers?" or "find APIs with OpenAPI specs"
+- User wants to discover agent-friendly services in a specific category
+- User needs to evaluate whether a site is agent-ready
+
+## Steps
+
+1. Call `search_agents` with a keyword query, category filter, or minimum score
+2. Review results — each includes domain, score, and detected capabilities
+3. Call `get_site_details` on promising domains for a full readiness breakdown
+
+## Filters
+
+- `q` — keyword search (e.g. "code review", "payments")
+- `category` — ai-tools, developer, data, finance, ecommerce, jobs, security, health, education
+- `min_score` — minimum agentic readiness score (0-100)
+- `has_mcp` — only sites with MCP servers
+- `has_openapi` — only sites with OpenAPI specs
+- `has_llms_txt` — only sites publishing llms.txt
+
+## Example
+
+"Find AI tools with MCP servers scored above 80"
+
+```
+search_agents(q="ai tools", min_score=80, has_mcp=true)
+```


### PR DESCRIPTION
## Summary

- Adds **Not Human Search MCP** plugin — search engine for AI agents with 8,600+ indexed sites scored by agentic readiness (0-100). 5 tools: search_agents, get_site_details, submit_site, get_stats, register_monitor.
- Adds **AI Dev Jobs MCP** plugin — curated AI/ML job board with 5,400+ roles from 280+ companies. 5 tools: search_jobs, get_job, list_companies, get_stats, match_jobs.
- Both use remote `streamable-http` MCP endpoints (no local install needed)
- No API key required — all tools are free

## Plugin Contents

### nothumansearch-mcp
- `plugin.json` — manifest with metadata, keywords, and inline mcpServers config
- `mcp.json` — standalone MCP server config
- 2 skills: `search-agents` and `score-site`
- README, CHANGELOG, LICENSE

### aidevjobs-mcp
- `plugin.json` — manifest with metadata, keywords, and inline mcpServers config
- `mcp.json` — standalone MCP server config
- 2 skills: `search-jobs` and `match-candidate`
- README, CHANGELOG, LICENSE

## Links

### Not Human Search
- Website: https://nothumansearch.ai
- MCP endpoint: https://nothumansearch.ai/mcp
- GitHub: https://github.com/unitedideas/nothumansearch
- MCP Registry: https://registry.modelcontextprotocol.io (listed as ai.nothumansearch/search)

### AI Dev Jobs
- Website: https://aidevboard.com
- MCP endpoint: https://aidevboard.com/mcp
- GitHub: https://github.com/unitedideas/aidevboard-mcp
- MCP Registry: https://registry.modelcontextprotocol.io (listed as com.aidevboard/jobs)

## Validation

Validated locally with `validate-plugins.mjs` — all checks pass.