### PR TITLE
Add mem-forever: persistent memory across sessions and tools

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -52,6 +52,11 @@
       "name": "docs-canvas",
       "source": "docs-canvas",
       "description": "Render documentation — architecture notes, API references, runbooks, and codebase walkthroughs — as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references."
+    },
+    {
+      "name": "mem-forever",
+      "source": "mem-forever",
+      "description": "Persistent memory across sessions and tools. Auto-generates a portable profile from conversation, saves decisions and lessons to .ilang/, applies preferences in every future session."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `cli-for-agent` | [CLI for Agents](cli-for-agent/) | Cursor | Developer Tools | Patterns for designing CLIs that coding agents can run reliably: flags, help with examples, pipelines, errors, idempotency, dry-run. |
 | `pr-review-canvas` | [PR Review Canvas](pr-review-canvas/) | Cursor | Developer Tools | Render PR diffs as interactive Cursor Canvases organized for reviewer comprehension — groups changes by importance, separates boilerplate from core logic, and highlights tricky or unexpected code. |
 | `docs-canvas` | [Docs Canvas](docs-canvas/) | Cursor | Developer Tools | Render documentation — architecture notes, API references, runbooks, and codebase walkthroughs — as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references. |
+| `mem-forever` | [Mem-Forever](mem-forever/) | I-Lang Protocol | Developer Tools | Persistent memory across sessions and tools. Auto-generates a portable profile from conversation, saves decisions and lessons to .ilang/, applies preferences in every future session. |
 
 Author values match each plugin’s `plugin.json` `author.name` (Cursor lists `plugins@cursor.com` in the manifest).
 

--- a/mem-forever/.cursor-plugin/plugin.json
+++ b/mem-forever/.cursor-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "mem-forever",
+  "displayName": "Mem-Forever",
+  "version": "1.0.0",
+  "description": "Persistent memory across sessions and tools. Auto-generates a portable profile from conversation, saves decisions and lessons to .ilang/, applies preferences in every future session. Works across Cursor, Claude Code, Codex, Copilot, and Gemini.",
+  "author": {
+    "name": "I-Lang Protocol",
+    "email": "hello@ilang.ai"
+  },
+  "homepage": "https://github.com/ilang-ai/Mem-Forever",
+  "repository": "https://github.com/ilang-ai/Mem-Forever",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "persistence",
+    "cross-session",
+    "cross-tool",
+    "portable-profile",
+    "i-lang"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "memory",
+    "productivity",
+    "automation"
+  ],
+  "skills": "./skills/"
+}

--- a/mem-forever/LICENSE
+++ b/mem-forever/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ilang-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mem-forever/README.md
+++ b/mem-forever/README.md
@@ -1,0 +1,32 @@
+# Mem-Forever
+
+Persistent memory across sessions and tools. Your AI remembers who you are, what you decided, and what you learned — forever.
+
+## Installation
+
+```
+/add-plugin mem-forever
+```
+
+## How it works
+
+On session start, the plugin reads `.ilang/soul.md` (your profile) and `.ilang/memory.md` (your logbook). If no profile exists, it runs a brief onboarding conversation to build one.
+
+During the session, significant decisions, lessons, and facts are appended to memory and committed to git immediately. No data is lost even if the session ends abruptly.
+
+The same `.ilang/` files work across Cursor, Claude Code, Codex, Copilot, and Gemini CLI — switch tools without losing context.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `.ilang/soul.md` | Behavioral profile, auto-generated from conversation |
+| `.ilang/memory.md` | Append-only logbook of decisions, lessons, facts |
+
+## Template repository
+
+For a dedicated memory repo with full setup, see [Mem-Forever template](https://github.com/ilang-ai/Mem-Forever).
+
+## License
+
+MIT

--- a/mem-forever/skills/mem-forever/SKILL.md
+++ b/mem-forever/skills/mem-forever/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: mem-forever
+description: Load and maintain persistent user memory from .ilang/soul.md and .ilang/memory.md. Run at session start to restore context, and after significant work to save new observations.
+---
+
+# Mem-Forever
+
+Persistent memory that survives every session, every tool switch, every migration.
+
+## Session Start
+
+1. Check `.ilang/` for uncommitted changes. If found, commit and push immediately.
+2. Read `.ilang/soul.md`. If empty or template-only, run onboarding.
+3. Read `.ilang/memory.md`. Resume context from last session.
+4. Apply preferences from soul.md to all output.
+
+## Onboarding (soul.md empty)
+
+Open casually. Ask ONE question per message. Cover: what they do, how they prefer to work, what tools they use. Create `.ilang/soul.md` when you have role + work style + one clear preference. Say "Saved some notes so things go smoother next time." Move on.
+
+## Memory Update
+
+Every time a significant decision, lesson, or fact emerges, append to `.ilang/memory.md`:
+
+```
+## YYYY-MM-DD
+::DECIDED{what|why|context}
+::LEARNED{what|from:error_or_observation}
+::FACT{key:value}
+::PROGRESS{done:what|next:what}
+```
+
+Commit and push immediately after each update. Do not batch to session end.
+
+## Rules
+
+- Append, never overwrite. Git history is version control.
+- Store patterns not events. Compress to structured format.
+- Never store secrets, API keys, passwords.
+- Max 200 lines in memory.md. Summarize oldest when exceeded.
+- Never say "DNA", "gene", "mutation", "decay" to user. Say "saved some notes" or "I remember from last time".
+- If user asks to see their profile, show soul.md openly.
+
+## Mutation
+
+- Repeated behavior (3x+): promote to confirmed in soul.md.
+- Explicit rejection: add as anti-pattern in soul.md.
+- One-off event: memory.md only, not soul.md.
+
+## Portability
+
+`.ilang/` files are plain text. Same memory works across Cursor, Claude Code, Codex, Copilot, Gemini, and any tool that reads markdown.


### PR DESCRIPTION
Mem-Forever auto-generates a portable user profile from conversation, saves decisions and lessons to .ilang/, and applies preferences in every future session. Works across Cursor, Claude Code, Codex, Copilot, and Gemini CLI.

- skills/mem-forever/SKILL.md: session start, onboarding, memory update, mutation rules
- .cursor-plugin/plugin.json: manifest with keywords and category
- Added to marketplace.json and README table

Homepage: https://github.com/ilang-ai/Mem-Forever