### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **content-first multi-plugin monorepo** for the Cursor Plugins marketplace. Most plugins are pure Markdown/JSON with no executable code. The two components with executable code are:
+
+### 1. Plugin validation (root level)
+- **What**: JSON schema validation of all plugin manifests
+- **Run**: `node scripts/validate-plugins.mjs` (from repo root)
+- **Deps**: `npm install --no-save ajv ajv-formats` (installed at root, no committed `package.json`)
+- **CI**: This is the main CI check (`.github/workflows/validate-plugins.yml`), triggered on changes to manifests or schemas
+
+### 2. Orchestrate CLI (`orchestrate/skills/orchestrate/scripts/`)
+- **Runtime**: Bun (ensure `~/.bun/bin` is on PATH)
+- **Deps**: `bun install` in the scripts directory
+- **Lint**: `bun run lint` (Biome 2.x)
+- **Typecheck**: `bun run typecheck` (TypeScript 6.x)
+- **Tests**: `bun test` (207 unit tests)
+- **Format**: `bun run format`
+- **Full check**: `bun run check` (format + typecheck)
+
+### Gotchas
+- There is no root `package.json`; the `ajv`/`ajv-formats` deps are installed ad-hoc with `--no-save` and land in a root `node_modules/`.
+- The orchestrate CLI requires `CURSOR_API_KEY` to actually spawn agents; tests run without it (mocked).
+- Slack integration (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID`) is optional; tests emit `SLACK_BOT_TOKEN not set; Slack visibility disabled` — this is expected.
+- No databases, Docker, or running services are needed for development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents.

## What this adds

- `AGENTS.md` documenting the two executable components in this content-first monorepo:
  1. **Plugin validation** — `node scripts/validate-plugins.mjs` (root level, requires `ajv`/`ajv-formats`)
  2. **Orchestrate CLI** — Bun-based TypeScript CLI with lint/typecheck/test commands
- Non-obvious gotchas (no root `package.json`, ad-hoc dependency install, mocked API keys in tests, expected Slack warnings)

## Environment verification

All checks pass:

| Check | Command | Result |
|-------|---------|--------|
| Plugin validation | `node scripts/validate-plugins.mjs` | All plugins validated successfully |
| Orchestrate lint | `bun run lint` (Biome) | 58 files checked, no issues |
| Orchestrate typecheck | `tsc --noEmit` | Clean |
| Orchestrate tests | `bun test` | 207 pass, 0 fail |

Test output:
[orchestrate_test_output.log](https://cursor.com/agents/bc-e7cb5c66-3aea-4d6e-b7f6-0da0d2e46e67/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forchestrate_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7cb5c66-3aea-4d6e-b7f6-0da0d2e46e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7cb5c66-3aea-4d6e-b7f6-0da0d2e46e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

