### PR TITLE
Add BuyWhere — Product Search & Price Comparison MCP plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -46,22 +46,27 @@
     {
       "name": "pr-review-canvas",
       "source": "pr-review-canvas",
-      "description": "Render PR diffs as interactive Cursor Canvases organized for reviewer comprehension — groups changes by importance, separates boilerplate from core logic, and highlights tricky or unexpected code."
+      "description": "Render PR diffs as interactive Cursor Canvases organized for reviewer comprehension \u2014 groups changes by importance, separates boilerplate from core logic, and highlights tricky or unexpected code."
     },
     {
       "name": "docs-canvas",
       "source": "docs-canvas",
-      "description": "Render documentation — architecture notes, API references, runbooks, and codebase walkthroughs — as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references."
+      "description": "Render documentation \u2014 architecture notes, API references, runbooks, and codebase walkthroughs \u2014 as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references."
     },
     {
       "name": "cursor-sdk",
       "source": "cursor-sdk",
-      "description": "Build apps, scripts, CI pipelines, and automations on top of the Cursor TypeScript SDK (@cursor/sdk) — runtime selection, auth, streaming, MCP, error handling, and ready-to-extend integration patterns."
+      "description": "Build apps, scripts, CI pipelines, and automations on top of the Cursor TypeScript SDK (@cursor/sdk) \u2014 runtime selection, auth, streaming, MCP, error handling, and ready-to-extend integration patterns."
     },
     {
       "name": "orchestrate",
       "source": "orchestrate",
       "description": "Fan large tasks out across parallel Cursor cloud agents with planners, workers, verifiers, and structured handoffs."
+    },
+    {
+      "name": "buywhere",
+      "source": "buywhere",
+      "description": "Search 1.5M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ platforms. Compare prices and find deals from Cursor."
     }
   ]
 }

--- a/buywhere/.cursor-plugin/plugin.json
+++ b/buywhere/.cursor-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "buywhere",
+  "displayName": "BuyWhere — Product Search & Price Comparison",
+  "version": "1.0.0",
+  "description": "Search 1.5M+ products across Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and 20+ Southeast Asia and US e-commerce platforms. Compare prices, discover deals, and find best prices directly from Cursor.",
+  "author": {
+    "name": "BuyWhere",
+    "email": "hello@buywhere.ai"
+  },
+  "homepage": "https://github.com/BuyWhere/buywhere",
+  "repository": "https://github.com/BuyWhere/buywhere",
+  "license": "MIT",
+  "keywords": [
+    "shopping",
+    "price-comparison",
+    "ecommerce",
+    "southeast-asia",
+    "product-search",
+    "deals",
+    "mcp",
+    "singapore",
+    "lazada",
+    "shopee",
+    "amazon"
+  ],
+  "category": "productivity",
+  "tags": [
+    "shopping",
+    "ecommerce",
+    "price-comparison",
+    "mcp-server"
+  ],
+  "skills": "./skills/"
+}

--- a/buywhere/README.md
+++ b/buywhere/README.md
@@ -1,0 +1,43 @@
+# BuyWhere — Product Search & Price Comparison
+
+Search 1.5M+ products across Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and 20+ Southeast Asia and US e-commerce platforms — directly from Cursor.
+
+## Installation
+
+```
+/add-plugin buywhere
+```
+
+## MCP Server
+
+Connects to the BuyWhere MCP endpoint at `https://api.buywhere.ai/mcp`, providing tools for:
+
+- **search_products** — full-text search across 20+ platforms by keyword, category, price range, and location
+- **get_deals** — find current deals and discounts
+- **list_categories** — browse product categories
+- **find_best_price** — compare prices across platforms for a given product
+
+## Quick start
+
+Once installed, ask Cursor:
+
+- "Find the best price for AirPods Pro in Singapore"
+- "Show me deals on laptops under $800 on Lazada and Shopee"
+- "Compare prices for Sony WH-1000XM5 across all platforms"
+- "What are the top deals in electronics today?"
+
+## Coverage
+
+| Market | Platforms |
+|--------|-----------|
+| Singapore | Shopee SG, Lazada SG, FairPrice, Carousell |
+| US | Amazon, Walmart |
+| Malaysia | Shopee MY, Lazada MY |
+| Thailand | Shopee TH, Lazada TH |
+| Vietnam | Shopee VN, Lazada VN |
+
+## Links
+
+- [GitHub](https://github.com/BuyWhere/buywhere)
+- [API Docs](https://api.buywhere.ai/openapi.json)
+- [Website](https://buywhere.ai)

--- a/buywhere/mcp.json
+++ b/buywhere/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "buywhere": {
+      "url": "https://api.buywhere.ai/mcp"
+    }
+  }
+}

--- a/buywhere/skills/product-search/SKILL.md
+++ b/buywhere/skills/product-search/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: product-search
+description: Search products, compare prices, and find deals across Shopee, Lazada, Amazon, Walmart, and 20+ Southeast Asia and US e-commerce platforms. Use when the user wants to find a product, compare prices, discover deals, or get shopping recommendations.
+---
+
+# Product Search
+
+## Trigger
+
+User wants to find a product, compare prices across platforms, find deals or discounts, or get shopping recommendations.
+
+## Workflow
+
+1. Identify the product, category, and target market (SG, US, MY, TH, VN).
+2. Call `search_products` with the product name, optional category, price range, and location.
+3. If the user wants the best price across platforms, call `find_best_price` with the product name.
+4. If the user wants current deals, call `get_deals` with optional category filter.
+5. Present results ranked by price, rating, or relevance as appropriate.
+6. Include platform name, price, currency, and a direct product URL in every result.
+
+## UTM Tracking
+
+Append `?utm_source=cursor&utm_medium=plugin&utm_campaign=buywhere_plugin` to all product URLs returned.
+
+## Output Format
+
+- List top 5 results with: platform, product name, price (with currency), rating, and URL
+- Highlight the best price option
+- Note any active deals or discounts


### PR DESCRIPTION
## Summary

This PR adds **BuyWhere** to the Cursor plugin marketplace — a product search and price comparison MCP plugin covering 1.5M+ products across 20+ Southeast Asia and US e-commerce platforms.

## What's included

- `buywhere/.cursor-plugin/plugin.json` — plugin metadata
- `buywhere/mcp.json` — MCP server config pointing to `https://api.buywhere.ai/mcp`
- `buywhere/README.md` — installation and usage docs
- `buywhere/skills/product-search/SKILL.md` — skill definition for product search, price comparison, and deal discovery
- `.cursor-plugin/marketplace.json` — added `buywhere` entry to the plugins array

## MCP tools

- `search_products` — search across Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and 20+ platforms
- `find_best_price` — compare prices across all platforms for a given product
- `get_deals` — surface current discounts and promotions
- `list_categories` — browse product categories

## Coverage

Singapore, Malaysia, Thailand, Vietnam, US markets — Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and more.

## Links

- GitHub: https://github.com/BuyWhere/buywhere
- MCP endpoint: https://api.buywhere.ai/mcp
- Website: https://buywhere.ai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds marketplace metadata/docs plus an MCP endpoint configuration; no changes to core runtime logic. Main risk is dependency on the external `https://api.buywhere.ai/mcp` service availability/behavior.
> 
> **Overview**
> Adds the **BuyWhere** plugin to the Cursor marketplace, including new plugin metadata (`buywhere/.cursor-plugin/plugin.json`), docs (`buywhere/README.md`), and a product-search skill definition (`buywhere/skills/product-search/SKILL.md`).
> 
> Registers the plugin’s MCP server configuration in `buywhere/mcp.json` pointing to `https://api.buywhere.ai/mcp`, and appends a `buywhere` entry to `.cursor-plugin/marketplace.json` (also normalizing a few existing descriptions to use escaped em-dashes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7850f6bd96511abc9af97170d07bd88e4e30c8ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->