### PR TITLE
continual-learning: write to user-scoped memory file by default

### DIFF
--- a/continual-learning/CHANGELOG.md
+++ b/continual-learning/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this plugin will be documented here.
+
+## Unreleased
+
+- Default memory file moved to a user-scoped path
+  (`~/.cursor/projects/<workspace-slug>/AGENTS.local.md`) so the plugin is safe
+  to enable inside team repositories. The repository's `AGENTS.md` /
+  `CLAUDE.md` / `GEMINI.md` is no longer written by default.
+- Cadence and incremental-index state moved out of `.cursor/hooks/state/`
+  into `~/.cursor/projects/<workspace-slug>/continual-learning/`. Legacy
+  state files are migrated to the new location and removed from the
+  repository on first run (a backup copy is kept under the user-scoped state
+  directory).
+- New opt-in `CONTINUAL_LEARNING_WORKSPACE_FILE` env var lets users point
+  the plugin at a workspace-scoped memory file when they explicitly want
+  team-shareable workspace facts written somewhere inside the repo.
+- The hook now runs `git check-ignore` against any configured workspace
+  memory file and refuses to write to it when the file is inside a git repo
+  and not gitignored, unless `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
+- Added `CONTINUAL_LEARNING_USER_FILE`, `CONTINUAL_LEARNING_STATE_DIR`, and
+  `CONTINUAL_LEARNING_ALLOW_SHARED` env vars. All existing cadence env vars
+  are unchanged.
+- The hook now embeds the already-resolved target paths and any safety-check
+  block reason directly into the `followup_message`, so the
+  `agents-memory-updater` subagent does not need to recompute them.
+- Section routing made explicit: `## Learned User Preferences` always lives
+  in the user file; `## Learned Workspace Facts` lives in the workspace file
+  when configured and not blocked; a `## Learned Workspace Facts (local)`
+  fallback heading is used in the user file otherwise.

--- a/continual-learning/README.md
+++ b/continual-learning/README.md
@@ -1,16 +1,18 @@
 # Continual Learning
 
-Automatically and incrementally keeps `AGENTS.md` up to date from transcript changes.
+Automatically and incrementally keeps a memory file up to date from transcript
+changes.
 
 The plugin combines:
 
 - A `stop` hook that decides when to trigger learning.
 - A `continual-learning` skill that orchestrates the learning flow.
-- An `agents-memory-updater` subagent that mines new or changed transcripts and updates `AGENTS.md`.
+- An `agents-memory-updater` subagent that mines new or changed transcripts
+  and updates the memory file(s).
 
 It is designed to avoid noisy rewrites by:
 
-- Reading existing `AGENTS.md` first and updating matching bullets in place.
+- Reading the existing memory file first and updating matching bullets in place.
 - Processing only new or changed transcript files.
 - Writing plain bullet points only (no evidence/confidence metadata).
 
@@ -20,19 +22,37 @@ It is designed to avoid noisy rewrites by:
 /add-plugin continual-learning
 ```
 
+## Safe defaults for team repos
+
+This plugin defaults to writing to a **user-scoped** memory file outside the
+repository, so it is safe to enable inside repos shared with other people. By
+default it writes to:
+
+- Memory file: `~/.cursor/projects/<workspace-slug>/AGENTS.local.md`
+- State directory: `~/.cursor/projects/<workspace-slug>/continual-learning/`
+  - `cadence.json` — hook cadence state
+  - `index.json` — incremental transcript index
+
+`<workspace-slug>` mirrors Cursor's existing layout under
+`~/.cursor/projects/<slug>/agent-transcripts/`. Nothing is written inside the
+repository unless you opt in.
+
+The repository's `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` is **never** touched
+by default. If you want team-shareable workspace facts written somewhere
+inside the repo, set `CONTINUAL_LEARNING_WORKSPACE_FILE` to a path that is
+gitignored (or set `CONTINUAL_LEARNING_ALLOW_SHARED=1` to bypass the
+git-leak check at your own risk).
+
 ## How it works
 
-On eligible `stop` events, the hook may emit a `followup_message` that asks the agent to run the `continual-learning` skill.
+On eligible `stop` events, the hook may emit a `followup_message` that asks
+the agent to run the `continual-learning` skill. The followup message contains
+the already-resolved absolute paths for that run, so the subagent does not
+need to recompute them.
 
-The skill is marked `disable-model-invocation: true`, so it will not be auto-selected during normal model invocation. When it does run, it delegates the full memory update flow to `agents-memory-updater`.
-
-The hook keeps local runtime state in:
-
-- `.cursor/hooks/state/continual-learning.json` (cadence state)
-
-The updater uses an incremental transcript index at:
-
-- `.cursor/hooks/state/continual-learning-index.json`
+The skill is marked `disable-model-invocation: true`, so it will not be
+auto-selected during normal model invocation. When it does run, it delegates
+the full memory update flow to `agents-memory-updater`.
 
 ## Trigger cadence
 
@@ -48,7 +68,23 @@ Trial mode defaults (enabled in this plugin hook config):
 - minimum 15 minutes
 - automatically expires after 24 hours, then falls back to default cadence
 
-## Optional env overrides
+## Configuration (all env vars are optional)
+
+**Memory targets**
+
+- `CONTINUAL_LEARNING_USER_FILE` — absolute path to the user-scoped memory
+  file. Default: `~/.cursor/projects/<slug>/AGENTS.local.md`. Personal,
+  never shared.
+- `CONTINUAL_LEARNING_WORKSPACE_FILE` — absolute path to an optional
+  workspace-scoped memory file that may be shared with the team. Unset by
+  default. The plugin refuses to write to this file if it is inside a git
+  repo and not gitignored, unless `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
+- `CONTINUAL_LEARNING_STATE_DIR` — directory for `cadence.json` and
+  `index.json`. Default: `~/.cursor/projects/<slug>/continual-learning/`.
+- `CONTINUAL_LEARNING_ALLOW_SHARED` — set to `1` to bypass the git-leak
+  check for `CONTINUAL_LEARNING_WORKSPACE_FILE`. Use with care.
+
+**Cadence (unchanged)**
 
 - `CONTINUAL_LEARNING_MIN_TURNS` (or legacy `CONTINUOUS_LEARNING_MIN_TURNS`)
 - `CONTINUAL_LEARNING_MIN_MINUTES` (or legacy `CONTINUOUS_LEARNING_MIN_MINUTES`)
@@ -57,14 +93,26 @@ Trial mode defaults (enabled in this plugin hook config):
 - `CONTINUAL_LEARNING_TRIAL_MIN_MINUTES` (or legacy `CONTINUOUS_LEARNING_TRIAL_MIN_MINUTES`)
 - `CONTINUAL_LEARNING_TRIAL_DURATION_MINUTES` (or legacy `CONTINUOUS_LEARNING_TRIAL_DURATION_MINUTES`)
 
-## Output format in AGENTS.md
+## Output format
 
-The memory updater writes only:
+Section routing:
 
-- `## Learned User Preferences`
-- `## Learned Workspace Facts`
+- `## Learned User Preferences` → user memory file only.
+- `## Learned Workspace Facts` → workspace memory file when configured and
+  not blocked.
+- `## Learned Workspace Facts (local)` → user memory file when no workspace
+  file is configured or the workspace file is blocked.
 
 Each item is a plain bullet point.
+
+## Migration from older versions
+
+Older versions wrote state into the repository at
+`.cursor/hooks/state/continual-learning.json` and
+`.cursor/hooks/state/continual-learning-index.json`. On first run the hook
+copies any pre-existing legacy state into the new user-scoped location,
+leaves a `.legacy` copy next to each original (for recovery), and removes
+the originals so they stop appearing in `git status`.
 
 ## License
 

--- a/continual-learning/agents/agents-memory-updater.md
+++ b/continual-learning/agents/agents-memory-updater.md
@@ -1,47 +1,112 @@
 ---
 name: agents-memory-updater
-description: Mine high-signal transcript deltas, update `AGENTS.md`, and keep the incremental transcript index in sync.
+description: Mine high-signal transcript deltas, update the user-scoped memory file (and optionally a workspace memory file), and keep the incremental transcript index in sync.
 model: inherit
 ---
 
-# AGENTS.md memory updater
+# Memory updater
 
 Own the full memory update flow for continual learning.
 
 ## Trigger
 
-Use from `continual-learning` when transcript deltas may produce durable memory updates.
+Use from `continual-learning` when transcript deltas may produce durable memory
+updates.
+
+## Target files
+
+The plugin separates personal learnings from team-shareable ones at the file
+level so it is safe to run inside team repositories.
+
+**User memory file** (always written, personal, never committed):
+
+- Path: `$CONTINUAL_LEARNING_USER_FILE` if set; otherwise
+  `~/.cursor/projects/<workspace-slug>/AGENTS.local.md`.
+  `<workspace-slug>` is the absolute workspace path with the leading `/`
+  stripped and remaining `/` replaced by `-` (e.g. `/Users/yury/Dev/qvac/wb`
+  → `Users-yury-Dev-qvac-wb`). This matches Cursor's existing
+  `~/.cursor/projects/<slug>/agent-transcripts/` convention.
+- Owns `## Learned User Preferences`.
+- Owns `## Learned Workspace Facts (local)` whenever no safe workspace file is
+  available.
+
+**Workspace memory file** (opt-in, may be committed and read by the whole team):
+
+- Path: `$CONTINUAL_LEARNING_WORKSPACE_FILE`. Unset by default — skip workspace
+  writes entirely when unset.
+- Owns `## Learned Workspace Facts` only.
+- Safety check: from the workspace root, run
+  `git check-ignore -q -- <workspace file>`. Exit `1` means the file is inside
+  a git repo and NOT gitignored, so writing to it would leak into the team's
+  commits — refuse the write unless `CONTINUAL_LEARNING_ALLOW_SHARED=1`. When
+  blocked, route those facts into the user file under
+  `## Learned Workspace Facts (local)` instead.
+
+**Incremental index and cadence**:
+
+- `$CONTINUAL_LEARNING_STATE_DIR` if set; otherwise
+  `~/.cursor/projects/<workspace-slug>/continual-learning/`.
+- Index: `<state-dir>/index.json`.
+- Cadence (owned by the stop hook): `<state-dir>/cadence.json`.
+
+When invoked from the stop hook, the followup message contains the already-
+resolved absolute paths for this run. Use those verbatim and skip the env-var
+resolution above.
 
 ## Workflow
 
-1. Read existing `AGENTS.md` first. If it does not exist, create it with only:
-   - `## Learned User Preferences`
-   - `## Learned Workspace Facts`
-2. Load the incremental index if present.
-3. Inspect only transcript files under `~/.cursor/projects/<workspace-slug>/agent-transcripts/` that are new or have newer mtimes than the index.
-4. Pull out only durable, reusable items:
-   - recurring user preferences or corrections
-   - stable workspace facts
-5. Update `AGENTS.md` carefully:
+1. Resolve the target paths (use the ones embedded in the followup message
+   when present; otherwise apply the rules above). Verify the workspace file
+   safety check before treating it as writable.
+2. For each target memory file you may write to:
+   - Read the existing file if it exists.
+   - Otherwise prepare a new file containing only the section headings that
+     file owns (see "Target files").
+3. Load the incremental index from the resolved index path.
+4. Inspect only transcript files under
+   `~/.cursor/projects/<workspace-slug>/agent-transcripts/` that are new or
+   have newer mtimes than the index.
+5. Extract only durable, reusable items:
+   - recurring user preferences or corrections → user memory file
+   - stable workspace facts → workspace memory file when available and not
+     blocked; otherwise user memory file under
+     `## Learned Workspace Facts (local)`.
+6. Update each target file carefully:
    - update matching bullets in place
    - add only net-new bullets
    - deduplicate semantically similar bullets
-   - keep each learned section to at most 12 bullets
-6. Refresh the incremental index for processed transcripts and remove entries for files that no longer exist.
-7. If the merge produces no `AGENTS.md` changes, leave `AGENTS.md` unchanged but still refresh the index.
-8. If no meaningful updates exist, respond exactly: `No high-signal memory updates.`
+   - keep each section to at most 12 bullets
+7. Refresh the index for processed transcripts and remove entries for files
+   that no longer exist.
+8. If the merge produces no file changes, leave the memory files unchanged
+   but still refresh the index.
+9. If no meaningful updates exist, respond exactly:
+   `No high-signal memory updates.`
+10. If the workspace file was blocked by the git-leak check, say so plainly in
+    the summary, e.g. *"Workspace file blocked: not gitignored. Wrote workspace
+    facts to the user file under `## Learned Workspace Facts (local)`."*
 
 ## Guardrails
 
 - Use plain bullet points only.
-- Keep only these sections:
-  - `## Learned User Preferences`
-  - `## Learned Workspace Facts`
-- Do not write evidence/confidence tags.
-- Do not write process instructions, rationale, or metadata blocks.
+- Section headings allowed:
+  - `## Learned User Preferences` (user file)
+  - `## Learned Workspace Facts` (workspace file only)
+  - `## Learned Workspace Facts (local)` (user file fallback when no workspace
+    file is configured or it is blocked)
+- Never write evidence/confidence tags, process instructions, rationale, or
+  metadata blocks.
+- Never write to the workspace memory file when the git-leak check fails
+  unless `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
+- Never write directly to a repo-level `AGENTS.md` / `CLAUDE.md` /
+  `GEMINI.md` unless the user explicitly pointed
+  `CONTINUAL_LEARNING_WORKSPACE_FILE` at one AND set
+  `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
 - Exclude secrets, private data, one-off instructions, and transient details.
 
 ## Output
 
-- Updated `AGENTS.md` and `.cursor/hooks/state/continual-learning-index.json` when needed
+- Updated memory file(s) and the index when needed.
+- A short summary that lists which paths were written (or why a write was
+  skipped).
 - Otherwise exactly `No high-signal memory updates.`

--- a/continual-learning/hooks/continual-learning-stop.ts
+++ b/continual-learning/hooks/continual-learning-stop.ts
@@ -143,9 +143,9 @@ function buildFollowupMessage(
 ): string {
   const workspaceLine = targets.workspaceFile
     ? targets.workspaceFileBlocked
-      ? `Workspace memory file (\`${targets.workspaceFile}\`) is BLOCKED: ${targets.workspaceFileBlockReason} Do not write workspace facts to disk; mention the block in the summary instead.`
+      ? `Workspace memory file (\`${targets.workspaceFile}\`) is BLOCKED: ${targets.workspaceFileBlockReason} Do not write to that file; route any workspace facts to the user memory file under \`## Learned Workspace Facts (local)\` instead, and mention the block in the summary.`
       : `Workspace memory file (shared, may be committed): \`${targets.workspaceFile}\`. Write only durable, team-relevant workspace facts here.`
-    : "No workspace memory file is configured. Do NOT write to any file inside the workspace; keep all learnings in the user memory file.";
+    : "No workspace memory file is configured. Do not write to any file inside the workspace; route any workspace facts to the user memory file under `## Learned Workspace Facts (local)` instead.";
 
   return [
     "Run the `continual-learning` skill now. Use the `agents-memory-updater` subagent for the full memory update flow.",

--- a/continual-learning/hooks/continual-learning-stop.ts
+++ b/continual-learning/hooks/continual-learning-stop.ts
@@ -1,21 +1,16 @@
 /// <reference types="bun-types-no-globals/lib/index.d.ts" />
 
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import { stdin } from "bun";
 
-const STATE_PATH = resolve(".cursor/hooks/state/continual-learning.json");
-const INCREMENTAL_INDEX_PATH = resolve(
-  ".cursor/hooks/state/continual-learning-index.json"
-);
+import { migrateLegacyState, resolveMemoryTargets } from "./lib/memory-targets.ts";
+
 const DEFAULT_MIN_TURNS = 10;
 const DEFAULT_MIN_MINUTES = 120;
 const TRIAL_DEFAULT_MIN_TURNS = 3;
 const TRIAL_DEFAULT_MIN_MINUTES = 15;
 const TRIAL_DEFAULT_DURATION_MINUTES = 24 * 60;
-
-const FOLLOWUP_MESSAGE =
-  `Run the \`continual-learning\` skill now. Use the \`agents-memory-updater\` subagent for the full memory update flow. Use incremental transcript processing with index file \`${INCREMENTAL_INDEX_PATH}\`: only consider transcripts not in the index or transcripts whose mtime is newer than indexed mtime. Have the subagent refresh index mtimes, remove entries for deleted transcripts, and update \`AGENTS.md\` only for high-signal recurring user corrections and durable workspace facts. Exclude one-off/transient details and secrets. If no meaningful updates exist, respond exactly: No high-signal memory updates.`;
 
 interface StopHookInput {
   conversation_id: string;
@@ -62,7 +57,7 @@ function readEnvValue(primary: string, legacy: string): string | undefined {
   return process.env[primary] ?? process.env[legacy];
 }
 
-function loadState(): ContinuousLearningState {
+function loadState(statePath: string): ContinuousLearningState {
   const fallback: ContinuousLearningState = {
     version: 1,
     lastRunAtMs: 0,
@@ -72,12 +67,12 @@ function loadState(): ContinuousLearningState {
     trialStartedAtMs: null,
   };
 
-  if (!existsSync(STATE_PATH)) {
+  if (!existsSync(statePath)) {
     return fallback;
   }
 
   try {
-    const raw = readFileSync(STATE_PATH, "utf-8");
+    const raw = readFileSync(statePath, "utf-8");
     const parsed = JSON.parse(raw) as Partial<ContinuousLearningState>;
     if (parsed.version !== 1) {
       return fallback;
@@ -114,12 +109,12 @@ function loadState(): ContinuousLearningState {
   }
 }
 
-function saveState(state: ContinuousLearningState): void {
-  const directory = dirname(STATE_PATH);
+function saveState(statePath: string, state: ContinuousLearningState): void {
+  const directory = dirname(statePath);
   if (!existsSync(directory)) {
     mkdirSync(directory, { recursive: true });
   }
-  writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+  writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
 }
 
 function getTranscriptMtimeMs(transcriptPath: string | null | undefined): number | null {
@@ -143,10 +138,40 @@ async function parseHookInput<T>(): Promise<T> {
   return JSON.parse(text) as T;
 }
 
+function buildFollowupMessage(
+  targets: ReturnType<typeof resolveMemoryTargets>
+): string {
+  const workspaceLine = targets.workspaceFile
+    ? targets.workspaceFileBlocked
+      ? `Workspace memory file (\`${targets.workspaceFile}\`) is BLOCKED: ${targets.workspaceFileBlockReason} Do not write workspace facts to disk; mention the block in the summary instead.`
+      : `Workspace memory file (shared, may be committed): \`${targets.workspaceFile}\`. Write only durable, team-relevant workspace facts here.`
+    : "No workspace memory file is configured. Do NOT write to any file inside the workspace; keep all learnings in the user memory file.";
+
+  return [
+    "Run the `continual-learning` skill now. Use the `agents-memory-updater` subagent for the full memory update flow.",
+    "",
+    "Resolved targets for this run:",
+    `- User memory file (personal, never committed): \`${targets.userFile}\``,
+    `- ${workspaceLine}`,
+    `- Incremental transcript index: \`${targets.indexFile}\``,
+    "",
+    "Use incremental transcript processing: only consider transcripts not in the index, or transcripts whose mtime is newer than the indexed mtime. After processing, refresh index mtimes and remove entries for deleted transcripts.",
+    "",
+    "Routing:",
+    "- `## Learned User Preferences` → user memory file only.",
+    "- `## Learned Workspace Facts` → workspace memory file when configured and not blocked; otherwise user memory file under a `## Learned Workspace Facts (local)` heading.",
+    "",
+    "Exclude one-off / transient details and secrets. If no meaningful updates exist, respond exactly: No high-signal memory updates.",
+  ].join("\n");
+}
+
 async function main(): Promise<number> {
   try {
     const input = await parseHookInput<StopHookInput>();
-    const state = loadState();
+    const targets = resolveMemoryTargets();
+    migrateLegacyState(targets);
+
+    const state = loadState(targets.cadenceFile);
 
     if (input.generation_id && input.generation_id === state.lastProcessedGenerationId) {
       console.log(JSON.stringify({}));
@@ -222,18 +247,18 @@ async function main(): Promise<number> {
       state.lastRunAtMs = now;
       state.turnsSinceLastRun = 0;
       state.lastTranscriptMtimeMs = transcriptMtimeMs;
-      saveState(state);
+      saveState(targets.cadenceFile, state);
 
       console.log(
         JSON.stringify({
-          followup_message: FOLLOWUP_MESSAGE,
+          followup_message: buildFollowupMessage(targets),
         })
       );
       return 0;
     }
 
     state.turnsSinceLastRun = turnsSinceLastRun;
-    saveState(state);
+    saveState(targets.cadenceFile, state);
     console.log(JSON.stringify({}));
     return 0;
   } catch (error) {

--- a/continual-learning/hooks/lib/memory-targets.ts
+++ b/continual-learning/hooks/lib/memory-targets.ts
@@ -1,0 +1,172 @@
+/// <reference types="bun-types-no-globals/lib/index.d.ts" />
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Resolved on-disk locations the continual-learning plugin writes to.
+ *
+ * `userFile` is always per-user (default lives under
+ * `~/.cursor/projects/<workspace-slug>/`) and is the only target that is
+ * guaranteed safe on team repos.
+ *
+ * `workspaceFile` is opt-in via `CONTINUAL_LEARNING_WORKSPACE_FILE`. The hook
+ * resolves it and runs a git-leak check before allowing writes; the result of
+ * that check is reported in `workspaceFileBlockReason`.
+ */
+export interface MemoryTargets {
+  readonly workspaceCwd: string;
+  readonly workspaceSlug: string;
+  readonly stateDir: string;
+  readonly cadenceFile: string;
+  readonly indexFile: string;
+  readonly userFile: string;
+  readonly workspaceFile: string | null;
+  readonly workspaceFileBlocked: boolean;
+  readonly workspaceFileBlockReason: string | null;
+  readonly allowShared: boolean;
+}
+
+/**
+ * Convert an absolute workspace path to the slug Cursor uses for
+ * `~/.cursor/projects/<slug>/`. Mirrors the convention already used by
+ * the agent-transcripts directory: drop the leading `/`, then `/` → `-`.
+ */
+export function computeWorkspaceSlug(workspaceCwd: string): string {
+  const abs = resolve(workspaceCwd);
+  return abs.replace(/^\//, "").replace(/\//g, "-");
+}
+
+function readEnv(name: string): string | undefined {
+  const raw = process.env[name];
+  return raw && raw.trim().length > 0 ? raw : undefined;
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
+}
+
+function expandPath(value: string, workspaceCwd: string): string {
+  let expanded = value;
+  if (expanded.startsWith("~/") || expanded === "~") {
+    expanded = expanded === "~" ? homedir() : join(homedir(), expanded.slice(2));
+  }
+  return isAbsolute(expanded) ? expanded : resolve(workspaceCwd, expanded);
+}
+
+/**
+ * Run `git check-ignore` from the workspace root. Returns true when the path
+ * is inside a git repo and is NOT ignored — i.e. writing to it would leak the
+ * file into the team's commits.
+ */
+export function isPathTeamShared(workspaceCwd: string, filePath: string): boolean {
+  const result = spawnSync(
+    "git",
+    ["-C", workspaceCwd, "check-ignore", "-q", "--", filePath],
+    { stdio: "ignore" }
+  );
+  if (result.error || typeof result.status !== "number") {
+    return false;
+  }
+  return result.status === 1;
+}
+
+export function resolveMemoryTargets(workspaceCwd = process.cwd()): MemoryTargets {
+  const slug = computeWorkspaceSlug(workspaceCwd);
+  const userProjectRoot = join(homedir(), ".cursor", "projects", slug);
+
+  const stateDir = readEnv("CONTINUAL_LEARNING_STATE_DIR")
+    ? expandPath(readEnv("CONTINUAL_LEARNING_STATE_DIR")!, workspaceCwd)
+    : join(userProjectRoot, "continual-learning");
+
+  const userFile = readEnv("CONTINUAL_LEARNING_USER_FILE")
+    ? expandPath(readEnv("CONTINUAL_LEARNING_USER_FILE")!, workspaceCwd)
+    : join(userProjectRoot, "AGENTS.local.md");
+
+  const allowShared = parseBoolean(readEnv("CONTINUAL_LEARNING_ALLOW_SHARED"));
+
+  let workspaceFile: string | null = null;
+  let workspaceFileBlocked = false;
+  let workspaceFileBlockReason: string | null = null;
+
+  const workspaceFileRaw = readEnv("CONTINUAL_LEARNING_WORKSPACE_FILE");
+  if (workspaceFileRaw) {
+    workspaceFile = expandPath(workspaceFileRaw, workspaceCwd);
+    if (!allowShared && isPathTeamShared(workspaceCwd, workspaceFile)) {
+      workspaceFileBlocked = true;
+      workspaceFileBlockReason =
+        `${workspaceFile} is inside a git repo and not gitignored; ` +
+        "set CONTINUAL_LEARNING_ALLOW_SHARED=1 to write to it anyway.";
+    }
+  }
+
+  return {
+    workspaceCwd: resolve(workspaceCwd),
+    workspaceSlug: slug,
+    stateDir,
+    cadenceFile: join(stateDir, "cadence.json"),
+    indexFile: join(stateDir, "index.json"),
+    userFile,
+    workspaceFile,
+    workspaceFileBlocked,
+    workspaceFileBlockReason,
+    allowShared,
+  };
+}
+
+/**
+ * Old plugin versions kept cadence + index inside the workspace at
+ * `.cursor/hooks/state/`. If those files exist, copy them once into the new
+ * user-scoped location (and a sibling `.legacy.<basename>` backup) and remove
+ * the originals so they stop polluting `git status` on team repos.
+ */
+export function migrateLegacyState(targets: MemoryTargets): void {
+  const legacyCadence = resolve(
+    targets.workspaceCwd,
+    ".cursor/hooks/state/continual-learning.json"
+  );
+  const legacyIndex = resolve(
+    targets.workspaceCwd,
+    ".cursor/hooks/state/continual-learning-index.json"
+  );
+
+  const pairs: ReadonlyArray<readonly [string, string]> = [
+    [legacyCadence, targets.cadenceFile],
+    [legacyIndex, targets.indexFile],
+  ];
+
+  for (const [from, to] of pairs) {
+    if (!existsSync(from)) {
+      continue;
+    }
+    try {
+      const contents = readFileSync(from, "utf-8");
+      mkdirSync(dirname(to), { recursive: true });
+      if (!existsSync(to)) {
+        writeFileSync(to, contents, "utf-8");
+      }
+      // Keep a backup outside the repo under the user-scoped state dir so the
+      // original content is recoverable without polluting `git status`.
+      const backup = join(targets.stateDir, `legacy.${basename(from)}`);
+      if (!existsSync(backup)) {
+        writeFileSync(backup, contents, "utf-8");
+      }
+      // Remove the original so it no longer shows up in `git status`.
+      const fs = require("node:fs") as typeof import("node:fs");
+      fs.rmSync(from, { force: true });
+    } catch {
+      // best effort
+    }
+  }
+}

--- a/continual-learning/skills/continual-learning/SKILL.md
+++ b/continual-learning/skills/continual-learning/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: continual-learning
-description: Orchestrate continual learning by delegating transcript mining and AGENTS.md updates to `agents-memory-updater`.
+description: Orchestrate continual learning by delegating transcript mining and memory-file updates to `agents-memory-updater`.
 disable-model-invocation: true
 ---
 
 # Continual Learning
 
-Keep `AGENTS.md` current by delegating the memory update flow to one subagent.
+Keep the user-scoped memory file (and optionally a workspace-scoped memory
+file) current by delegating the memory update flow to one subagent.
 
 ## Trigger
 


### PR DESCRIPTION
## Summary

Make the `continual-learning` plugin safe to enable inside team repositories.

Today the plugin defaults to writing learned bullets into the workspace
`AGENTS.md` and keeping its cadence + incremental-index state under
`.cursor/hooks/state/`. On a shared repo both of those paths are owned by
every contributor, so:

- personal preferences end up committed into the team's instructions, and
- the two state JSON files permanently show up in `git status` as untracked
  noise (or get committed by accident).

This PR moves the defaults to user-scoped locations under
`~/.cursor/projects/<workspace-slug>/` — the same directory layout Cursor
already uses for `agent-transcripts/` — and keeps any write inside the repo
strictly opt-in.

## What changes

- **New defaults**
  - Memory file: `~/.cursor/projects/<slug>/AGENTS.local.md` (personal,
    never committed). Cursor's stacked `AGENTS.md` loading picks it up
    automatically.
  - State dir: `~/.cursor/projects/<slug>/continual-learning/` with
    `cadence.json` (hook state) and `index.json` (incremental index).
- **Opt-in shared file** via `CONTINUAL_LEARNING_WORKSPACE_FILE`. If set,
  the hook runs `git check-ignore` against it and refuses to write when the
  file is inside a git repo and not gitignored. The check can be bypassed
  with `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
- **Explicit section routing**
  - `## Learned User Preferences` → user file only.
  - `## Learned Workspace Facts` → workspace file when configured and not
    blocked.
  - `## Learned Workspace Facts (local)` → user file fallback heading
    when no workspace file is configured or the workspace file is blocked.
- **Hook embeds resolved paths in `followup_message`** so the
  `agents-memory-updater` subagent gets concrete absolute paths and the
  block reason (if any) instead of having to recompute them.
- **First-run migration** copies any pre-existing
  `.cursor/hooks/state/continual-learning{,-index}.json` into the new
  user-scoped location, keeps a backup under the user state dir, and
  removes the originals so they stop appearing in `git status`.
- **New env vars** (all optional): `CONTINUAL_LEARNING_USER_FILE`,
  `CONTINUAL_LEARNING_WORKSPACE_FILE`, `CONTINUAL_LEARNING_STATE_DIR`,
  `CONTINUAL_LEARNING_ALLOW_SHARED`. Existing cadence vars and legacy
  `CONTINUOUS_LEARNING_*` aliases are unchanged.

## Files

- `continual-learning/hooks/continual-learning-stop.ts` — use resolved
  targets for state paths; build a structured followup message; migrate
  legacy state once on startup.
- `continual-learning/hooks/lib/memory-targets.ts` *(new)* — slug
  computation, env-driven path resolution, `git check-ignore` safety check,
  legacy-state migration. ~180 lines, no new dependencies (`node:fs`,
  `node:os`, `node:path`, `node:child_process` only).
- `continual-learning/agents/agents-memory-updater.md` — describe the
  dual-target write model, the section-routing rules, the safety check, and
  the local-fallback heading. Prefers the embedded paths from the hook when
  present.
- `continual-learning/skills/continual-learning/SKILL.md` — header wording
  updated; orchestration unchanged.
- `continual-learning/README.md` — new "Safe defaults for team repos" and
  expanded configuration sections.
- `continual-learning/CHANGELOG.md` *(new)* — `Unreleased` entry following
  the format used by sibling plugins.

## Backwards compatibility

- Default memory file path changes from workspace `AGENTS.md` to
  `~/.cursor/projects/<slug>/AGENTS.local.md`. Existing users who relied on
  the old behavior can restore it by setting
  `CONTINUAL_LEARNING_WORKSPACE_FILE=<absolute path to AGENTS.md>` and
  `CONTINUAL_LEARNING_ALLOW_SHARED=1`.
- All existing env vars (`CONTINUAL_LEARNING_MIN_TURNS`, trial mode flags,
  the `CONTINUOUS_LEARNING_*` legacy aliases) keep their current meaning.
- Existing cadence/index files in `.cursor/hooks/state/` are migrated
  automatically on the next hook run.

## Test plan

- [x] `node scripts/validate-plugins.mjs` — passes (no manifest changes).
- [x] `bun build continual-learning/hooks/continual-learning-stop.ts` —
      bundles cleanly.
- [x] Cold run (no transcript advance) — hook outputs `{}` and does not
      trigger the followup.
- [x] Forced trigger with no workspace file configured — followup message
      contains the resolved user file path and routes workspace facts to
      the user file under `## Learned Workspace Facts (local)`.
- [x] Forced trigger with `CONTINUAL_LEARNING_WORKSPACE_FILE` pointing at a
      tracked file — followup message marks the workspace target as
      `BLOCKED` with the git-leak reason and routes workspace facts to the
      user file under `## Learned Workspace Facts (local)`.
- [x] Same scenario with `CONTINUAL_LEARNING_ALLOW_SHARED=1` — followup
      message labels the workspace target as `shared, may be committed` and
      allows the write.
- [x] First-run migration on a workspace that has the old
      `.cursor/hooks/state/` files — files are moved to the user-scoped
      location, a backup is left there, and the originals are removed from
      `git status`.

Made with [Cursor](https://cursor.com)