### PR TITLE
pstack: complete README skills table

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -54,6 +54,7 @@ the rest are useful when you want to specifically invoke them:
 | `/automate-me` | you want your own `-mode` skill, drafted from how you've actually worked. |
 | `/reflect` | a long task landed and you want the recipe captured as a skill edit. |
 | `/tdd` | you're fixing a bug and there's a cheap local test path. write the failing test first, then the fix. |
+| `/typescript-best-practices` | you're reading or editing typescript. grounds the type-system-discipline principle in syntax. |
 | `/unslop` | you're cleaning up writing. removes AI tells. |
 
 ## the `poteto-agent` subagent


### PR DESCRIPTION
## summary

audited the pstack README's skills table and principles section against what actually ships under `pstack/skills/`.

- **skills table**: the table listed every shipped non-principle skill except `typescript-best-practices`. added a row for it in the README's existing lowercase, plain voice, placed with the other code-quality skills.
- **principles section**: audited all eighteen `principle-*` dirs against the section. it already enumerates all eighteen, including `type-system-discipline` (architecture group), and the count is correct. no change needed.

## what changed

one row added to the skills table:

```
| `/typescript-best-practices` | you're reading or editing typescript. grounds the type-system-discipline principle in syntax. |
```

no other changes. targeted README fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just adds a missing entry to the skills table with no runtime or behavior impact.
> 
> **Overview**
> Updates `pstack/README.md` to include the missing `/typescript-best-practices` row in the skills table, describing when to use it and tying it to the `type-system-discipline` principle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6754d3c09e5ea95de453ac1330f8648a82bbe00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->