### PR TITLE
pstack: harden show-me-your-work log.sh (formula-injection + mkdir -p) and shorten skill descriptions

### DIFF
--- a/pstack/skills/figure-it-out/SKILL.md
+++ b/pstack/skills/figure-it-out/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figure-it-out
-description: "Design a rigorous, auditable playbook for a task too large or cross-cutting for a single bundled playbook, or that no playbook fits: a migration across many call sites, an ambitious multi-part change, novel or ambiguous multi-phase work, or anything a human reviews after stepping away. Scales rigor to the task and biases toward more, runs a hypothesis-driven loop, and keeps a decision trail via show-me-your-work. Use for /figure-it-out, 'figure it out', a large migration, or when no narrower playbook is a good fit."
+description: "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a human reviews after stepping away. Scales rigor to the task, runs a hypothesis loop, and logs decisions via show-me-your-work. Use for /figure-it-out, 'figure it out', a large migration, or when no narrower playbook applies."
 disable-model-invocation: true
 ---
 

--- a/pstack/skills/show-me-your-work/SKILL.md
+++ b/pstack/skills/show-me-your-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: show-me-your-work
-description: "Keep a reviewable decision trail for non-trivial, long-running, or unattended work. A TSV log with one row per decision (what, why, evidence, result). Kept local by default; commit it for ambitious, high-stakes work where a reviewer needs the trail to trust the result (a large port, a multi-week migration), where GitHub renders it as a table. Use for /show-me-your-work, autonomous or multi-phase runs, or work a human reviews after stepping away. Composed by figure-it-out, autonomous-run, and multi-phase plans."
+description: "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, evidence, result). Local by default; commit it when a reviewer needs the trail to trust the result. Use for /show-me-your-work, autonomous or multi-phase runs, or work a human reviews after stepping away."
 disable-model-invocation: true
 ---
 
@@ -35,7 +35,7 @@ ts	phase	decision	why	evidence	result
 
 Write each entry the way you'd tell a teammate what you did. Plain words, concrete actions, no AI speak or abstract jargon (the **unslop** skill applies to log text too). A reviewer should understand each row without decoding it.
 
-Use the helper so rows stay well-formed: `scripts/log.sh <logfile> <phase> <decision> <why> <evidence> <result>`. It stamps `ts`, writes the header on first use, and strips stray tabs. A bare `printf` appending a row works too.
+Use the helper so rows stay well-formed: `scripts/log.sh <logfile> <phase> <decision> <why> <evidence> <result>`. It stamps `ts`, writes the header on first use, strips stray tabs/newlines, and prefixes any cell starting with `=`, `+`, `-`, or `@` with a single quote so a reviewer opening the log in a spreadsheet doesn't trigger formula execution. A bare `printf` appending a row works too, but mind those same bytes if cells come from generated or user-supplied text.
 
 Log decision points and checkpoints, not every action: a fork chosen, a unit completed with its verification result, a pivot or revert with its trigger, a blocker surfaced, a gate fixed. For loop runs, one row per iteration. Skip the trivial and self-evident.
 

--- a/pstack/skills/show-me-your-work/scripts/log.sh
+++ b/pstack/skills/show-me-your-work/scripts/log.sh
@@ -11,12 +11,30 @@ fi
 logfile="$1"
 shift
 
+logdir="$(dirname "$logfile")"
+if [ -n "$logdir" ] && [ "$logdir" != "." ] && [ ! -d "$logdir" ]; then
+	mkdir -p "$logdir"
+fi
+
 if [ ! -f "$logfile" ]; then
 	printf 'ts\tphase\tdecision\twhy\tevidence\tresult\n' > "$logfile"
 fi
 
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-clean() { printf '%s' "$1" | tr '\t\n' '  '; }
+# Strip tabs/newlines/CR so cells stay on one line, and prefix any cell
+# whose first char a spreadsheet would parse as a formula (=, +, -, @)
+# with a single quote. The skill expects this log to be read in
+# spreadsheets, so attacker-controlled evidence (PR titles, filenames,
+# generated text) must not become formula execution when a reviewer
+# opens the file.
+clean() {
+	local v
+	v=$(printf '%s' "$1" | tr '\t\n\r' '   ')
+	case "$v" in
+		=*|+*|-*|@*) printf "'%s" "$v" ;;
+		*) printf '%s' "$v" ;;
+	esac
+}
 printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
 	"$ts" "$(clean "$1")" "$(clean "$2")" "$(clean "$3")" "$(clean "$4")" "$(clean "$5")" \
 	>> "$logfile"


### PR DESCRIPTION
## Summary

Ports three fixes the everysphere `babysit` run surfaced, which landed in everysphere but were missed when the pstack twin merged (#78). These are content-identical to the merged everysphere versions for these specific changes; the descriptions don't reference internal mode names, and `log.sh` has no path/naming differences, so they port verbatim.

### 1. `pstack/skills/show-me-your-work/scripts/log.sh` (security + logic)

- **CSV/TSV formula-injection sanitization:** `clean()` now prefixes any cell whose first character a spreadsheet would parse as a formula (`=`, `+`, `-`, `@`) with a single quote, and strips `\r` in addition to tabs/newlines. The skill expects this log to be opened in spreadsheets, so attacker-controlled evidence (PR titles, filenames, generated text) must not become formula execution when a reviewer opens the file.
- **`mkdir -p` the parent dir:** the log's parent directory is created before the first write, so nested log paths (e.g. `.audit/<task>.tsv`) don't fail.

### 2. `pstack/skills/show-me-your-work/SKILL.md`

- The "Logging a row" helper section now mentions the sanitization (strips tabs/newlines and quote-prefixes formula cells).
- Shortened the frontmatter `description`.

### 3. `pstack/skills/figure-it-out/SKILL.md`

- Shortened the frontmatter `description`, preserving the routing-critical trigger phrases (`large migration`, `/figure-it-out`, `'figure it out'`) that an eval validated to fix figure-it-out's routing.

## Test plan

- [x] `shellcheck log.sh` clean
- [x] Smoke test: `bash log.sh /tmp/x/y/z.tsv frame "=danger" why ev open` creates the nested dir and writes the `=danger` cell as `'=danger`
- [x] `log.sh` byte-identical to the merged everysphere version; tab-indented; executable bit preserved (`100755`)
- [x] No em dashes introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bash and documentation changes in agent skills; formula-prefix hardening reduces spreadsheet risk when reviewers open audit TSVs.
> 
> **Overview**
> Ports **show-me-your-work** hardening and shorter skill frontmatter into `pstack`, aligned with the already-merged everysphere twin.
> 
> **`scripts/log.sh`** now creates the log file’s parent directory with `mkdir -p` so paths like `.audit/<task>.tsv` work on first write. **`clean()`** strips carriage returns and prefixes cells that start with spreadsheet formula triggers (`=`, `+`, `-`, `@`) with a single quote so evidence from PR titles, paths, or generated text cannot execute as formulas when someone opens the TSV in Excel or similar.
> 
> **show-me-your-work** `SKILL.md` documents that behavior in the logging section and tightens the YAML `description`. **figure-it-out** only shortens its `description` while keeping routing phrases such as `/figure-it-out` and `large migration`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5275158c1c7b29e0100ba89810e83ec9335ab7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->