### PR TITLE
pstack: add figure-it-out and show-me-your-work to README examples

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -64,22 +64,24 @@ the rest are useful when you want to specifically invoke them:
 mostly i type `/poteto-mode` at the start of a task and let it route to a playbook. the other skills fire as the steps need them. a few i reach for directly.
 
 ```
-bug fix:       /poteto-mode this pr has a subtle bug where the scroll drifts every 750ms even when idle. repro first, then fix and verify.
-perf:          /poteto-mode a big list takes a second or two to load even though we virtualize. run a cpu trace and tell me why.
-feature:       /poteto-mode build a small feature behind a feature flag. verify it really works.
-prototype:     /poteto-mode build two prototypes of the markdown renderer so we can compare. spawn an agent for each.
-multi-phase:   /poteto-mode open source these skills as a plugin. nothing internal leaks, work in a temp dir, show me the dependency graph first.
-overnight run: /poteto-mode i'm going to bed. land the stack even if ci flakes. i want everything merged by morning.
-visual parity: /poteto-mode the row spacing is too tall when this flag is on. the second image is correct. repro and fix until it matches.
-how:           /how do we cancel runs? do we have an n+1 when we look up every run to cancel?
-why:           /why is this feature flag not on yet?
-architect:     design this instrumentation to be high signal with no false positives. /architect this first.
-arena:         /arena take my prompt to the arena verbatim. i want to compare their proposals with yours.
-interrogate:   /interrogate review this pr.
-tdd:           /tdd implement
-unslop:        can we unslop and tighten the new changes?
-reflect:       /reflect that took too long. capture what we learned so the next run doesn't repeat it.
-automate-me:   /automate-me
+bug fix:           /poteto-mode this pr has a subtle bug where the scroll drifts every 750ms even when idle. repro first, then fix and verify.
+perf:              /poteto-mode a big list takes a second or two to load even though we virtualize. run a cpu trace and tell me why.
+feature:           /poteto-mode build a small feature behind a feature flag. verify it really works.
+prototype:         /poteto-mode build two prototypes of the markdown renderer so we can compare. spawn an agent for each.
+multi-phase:       /poteto-mode open source these skills as a plugin. nothing internal leaks, work in a temp dir, show me the dependency graph first.
+overnight run:     /poteto-mode i'm going to bed. land the stack even if ci flakes. i want everything merged by morning.
+visual parity:     /poteto-mode the row spacing is too tall when this flag is on. the second image is correct. repro and fix until it matches.
+figure it out:     /poteto-mode i'm stepping away. migrate every caller from the synchronous store to the new async one, keeping behavior identical. i want to trust it was done right when i'm back.
+how:               /how do we cancel runs? do we have an n+1 when we look up every run to cancel?
+why:               /why is this feature flag not on yet?
+architect:         design this instrumentation to be high signal with no false positives. /architect this first.
+arena:             /arena take my prompt to the arena verbatim. i want to compare their proposals with yours.
+interrogate:       /interrogate review this pr.
+tdd:               /tdd implement
+unslop:            can we unslop and tighten the new changes?
+reflect:           /reflect that took too long. capture what we learned so the next run doesn't repeat it.
+show-me-your-work: /show-me-your-work keep a decision trail i can review when i'm back.
+automate-me:       /automate-me
 ```
 
 ## the `poteto-agent` subagent

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -64,22 +64,33 @@ the rest are useful when you want to specifically invoke them:
 mostly i type `/poteto-mode` at the start of a task and let it route to a playbook. the other skills fire as the steps need them. a few i reach for directly.
 
 ```
-bug fix:           /poteto-mode this pr has a subtle bug where the scroll drifts every 750ms even when idle. repro first, then fix and verify.
-perf:              /poteto-mode a big list takes a second or two to load even though we virtualize. run a cpu trace and tell me why.
+bug fix:           /poteto-mode this pr has a subtle bug where the scroll drifts every 750ms even
+                   when idle. repro first, then fix and verify.
+perf:              /poteto-mode a big list takes a second or two to load even though we virtualize.
+                   run a cpu trace and tell me why.
 feature:           /poteto-mode build a small feature behind a feature flag. verify it really works.
-prototype:         /poteto-mode build two prototypes of the markdown renderer so we can compare. spawn an agent for each.
-multi-phase:       /poteto-mode open source these skills as a plugin. nothing internal leaks, work in a temp dir, show me the dependency graph first.
-overnight run:     /poteto-mode i'm going to bed. land the stack even if ci flakes. i want everything merged by morning.
-visual parity:     /poteto-mode the row spacing is too tall when this flag is on. the second image is correct. repro and fix until it matches.
-figure it out:     /poteto-mode i'm stepping away. migrate every caller from the synchronous store to the new async one, keeping behavior identical. i want to trust it was done right when i'm back.
+prototype:         /poteto-mode build two prototypes of the markdown renderer so we can compare.
+                   spawn an agent for each.
+multi-phase:       /poteto-mode open source these skills as a plugin. nothing internal leaks, work
+                   in a temp dir, show me the dependency graph first.
+overnight run:     /poteto-mode i'm going to bed. land the stack even if ci flakes. i want
+                   everything merged by morning.
+visual parity:     /poteto-mode the row spacing is too tall when this flag is on. the second image
+                   is correct. repro and fix until it matches.
+figure it out:     /poteto-mode i'm stepping away. migrate every caller from the synchronous store
+                   to the new async one, keeping behavior identical. i want to trust it was done
+                   right when i'm back.
 how:               /how do we cancel runs? do we have an n+1 when we look up every run to cancel?
 why:               /why is this feature flag not on yet?
-architect:         design this instrumentation to be high signal with no false positives. /architect this first.
-arena:             /arena take my prompt to the arena verbatim. i want to compare their proposals with yours.
+architect:         design this instrumentation to be high signal with no false positives. /architect
+                   this first.
+arena:             /arena take my prompt to the arena verbatim. i want to compare their proposals
+                   with yours.
 interrogate:       /interrogate review this pr.
 tdd:               /tdd implement
 unslop:            can we unslop and tighten the new changes?
-reflect:           /reflect that took too long. capture what we learned so the next run doesn't repeat it.
+reflect:           /reflect that took too long. capture what we learned so the next run doesn't
+                   repeat it.
 show-me-your-work: /show-me-your-work keep a decision trail i can review when i'm back.
 automate-me:       /automate-me
 ```


### PR DESCRIPTION
## Summary

Adds usage examples for the two skills to the README `### examples` block.

- **`figure it out`** (poteto-mode-routed): a large, cross-cutting migration the user steps away from and reviews later.
- **`show-me-your-work`** (direct): keeping a reviewable decision trail.

Also realigns the example block's command column, since `show-me-your-work:` is now the longest label. The change to existing lines is whitespace only; their content is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or behavioral impact.
> 
> **Overview**
> The **`### examples`** code block now documents two skills that were already listed in the table but missing from copy-paste samples: a **`figure it out`** line routed through **`/poteto-mode`** (large async migration you review later) and a direct **`/show-me-your-work`** prompt for an auditable decision trail.
> 
> Existing example prompts are unchanged in wording; they are **re-wrapped and column-aligned** so labels line up with the longer **`show-me-your-work:`** label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 465c2fc5df3ae9699b8372c299e97486d32ce4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->