### PR TITLE
Add pstack to the root README plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `docs-canvas` | [Docs Canvas](docs-canvas/) | Cursor | Developer Tools | Render documentation — architecture notes, API references, runbooks, and codebase walkthroughs — as a navigable Cursor Canvas with sections, table of contents, diagrams, and cross-references. |
 | `cursor-sdk` | [Cursor SDK](cursor-sdk/) | Cursor | Developer Tools | Build apps, scripts, CI pipelines, and automations on top of the Cursor TypeScript SDK (@cursor/sdk) — runtime selection, auth, streaming, MCP, error handling, and ready-to-extend integration patterns. |
 | `orchestrate` | [Orchestrate](orchestrate/) | Cursor | Developer Tools | Fan large tasks out across parallel Cursor cloud agents with planners, workers, verifiers, and structured handoffs. |
+| `pstack` | [pstack](pstack/) | Lauren Tan | Developer Tools | if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. |
 
 Author values match each plugin’s `plugin.json` `author.name` (Cursor lists `plugins@cursor.com` in the manifest).
 


### PR DESCRIPTION
## Summary

Adds the `pstack` plugin to the `## Plugins` table in the root README. The `pstack/` directory shipped earlier but was never listed in the table.

Row uses the plugin's marketplace `description` and `author.name` from `pstack/.cursor-plugin/plugin.json`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation update with no runtime or security impact.
> 
> **Overview**
> Adds **`pstack`** to the root README **Plugins** table so the shipped `pstack/` plugin is listed alongside the other marketplace entries. The new row uses the plugin link, **Lauren Tan** as author, **Developer Tools** category, and the marketplace description from `pstack/.cursor-plugin/plugin.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0634b33d7453c7ca101b0f2357368b4a38c618ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->