### PR TITLE
pstack: add build-the-lever principle

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -103,9 +103,9 @@ pstack also ships a subagent that runs my style end to end. spawn it from a pare
 
 ## principles
 
-eighteen short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
+nineteen short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
 
-- core: laziness-protocol, foundational-thinking, redesign-from-first-principles, subtract-before-you-add, minimize-reader-load, outcome-oriented-execution, experience-first, exhaust-the-design-space.
+- core: laziness-protocol, foundational-thinking, redesign-from-first-principles, subtract-before-you-add, minimize-reader-load, outcome-oriented-execution, experience-first, exhaust-the-design-space, build-the-lever.
 - architecture: boundary-discipline, type-system-discipline, make-operations-idempotent, migrate-callers-then-delete-legacy-apis, separate-before-serializing-shared-state.
 - verification: prove-it-works, fix-root-causes.
 - delegation: guard-the-context-window, never-block-on-the-human.

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -38,6 +38,7 @@ Read the leaf skill in full for any principle you apply.
 - **Outcome-Oriented Execution.** The **principle-outcome-oriented-execution** skill. Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't preserve throwaway compatibility states.
 - **Experience First.** The **principle-experience-first** skill. Apply on product, UX, or feature-scope tradeoffs. Choose user delight over implementation convenience.
 - **Exhaust the Design Space.** The **principle-exhaust-the-design-space** skill. Apply on a novel interaction or architectural decision with no precedent. Build 2-3 competing prototypes and compare before committing.
+- **Build the Lever.** The **principle-build-the-lever** skill. Apply when work is repetitive or bulk. Build the tool that amortizes it (codemod, script, generator) once you know the recipe, instead of grinding by hand.
 
 **Architecture**
 

--- a/pstack/skills/principle-build-the-lever/SKILL.md
+++ b/pstack/skills/principle-build-the-lever/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: principle-build-the-lever
+description: "Apply when work is repetitive or bulk: many similar edits, a check you'll rerun, a population to transform. Build the tool that amortizes it (codemod, script, generator) once you know the recipe, instead of grinding by hand."
+disable-model-invocation: true
+---
+# Build the Lever
+
+When the work repeats, build the tool that does it instead of grinding by hand.
+
+**Why:** Doing the same edit a hundred times is slow and drifts into inconsistent mistakes. A codemod, generator, or script does it once, the same way every time, reruns for free, and gives a reviewer one artifact to check.
+
+**Pattern:** When you would otherwise repeat a transform, a check, or a setup more than a handful of times, build the lever instead.
+
+- Do the first few by hand to learn the exact recipe, then build the tool. Don't build on a guess.
+- Codemod or script for bulk edits, generator for repetitive files, a dump-to-sqlite query for repeated analysis, a rerunnable check for repeated verification.
+- Commit it when the work outlives the session, so the next run reruns it instead of redoing it.
+
+**Balance:** Leverage, not gold-plating. The [Laziness Protocol](../principle-laziness-protocol/SKILL.md) still holds. Build the lever only when it pays for itself across the remaining work, never for a one-off.
+
+Distinct from [Encode Lessons in Structure](../principle-encode-lessons-in-structure/SKILL.md), which makes a recurring instruction a durable guardrail. This is throughput on the work in front of you.


### PR DESCRIPTION
## Summary

Adds a general principle, `build-the-lever`, to the poteto-mode Principles set (Core group).

The disposition: when work is repetitive or bulk (many similar edits, a check you'll rerun, a population to transform), build the tool that amortizes it (codemod, generator, script, a dump-to-sqlite query) once you know the recipe, instead of grinding by hand. Do the first few by hand to learn the transform, then build the lever; commit it when the work outlives the session.

It is a principle rather than a playbook step because it applies on any task, not just one workflow.

**Balance:** leverage, not gold-plating. The Laziness Protocol still holds: build it only when it pays for itself across the remaining work. Distinct from encode-lessons-in-structure (durable guardrail for a recurring instruction) in that this is about throughput on the work in front of you.

Wired into the poteto-mode Principles index under Core, and the README principles count and core line updated (now nineteen).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill and index updates; no runtime or application code changes.
> 
> **Overview**
> Adds a new **Core** principle, **Build the Lever**, so agents favor codemods, scripts, or generators for repetitive or bulk work after learning the recipe by hand, instead of manual repetition.
> 
> A new `principle-build-the-lever` skill documents the rule (including balance with **Laziness Protocol** and distinction from **Encode Lessons in Structure**). **`poteto-mode`**’s inline principles index and **`README`** now list it and bump the principles count from eighteen to nineteen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96056b57ae12752ebfcf05af41d67101549e808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->