### PR TITLE
pstack: bump version to 0.2.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
## Summary

Bumps the pstack plugin version from `0.1.0` to `0.2.0`.

Since 0.1.0, this release adds:
- New playbooks: refactoring, session pickup, trace forensics, plus figure-it-out and show-me-your-work skills.
- New principle: build-the-lever.
- README refresh: skills table, examples section, and the playbooks rendered as a table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field version bump in plugin metadata with no runtime or security impact.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin manifest version from `0.1.0` to `0.2.0` in `pstack/.cursor-plugin/plugin.json`. No other files or metadata change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff199e3907ed8f0ea07bbcf97edfd056a0ead6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->