### PR TITLE
show-me-your-work: add cross-model review of the trail

### DIFF
--- a/pstack/skills/show-me-your-work/SKILL.md
+++ b/pstack/skills/show-me-your-work/SKILL.md
@@ -62,6 +62,17 @@ At the end of the run, before handing back, check the log told the truth. Read t
 
 Fix the log, not the story. If the work diverged from what a row claims, the row is wrong.
 
+## Cross-model review of the trail
+
+Before handing back, you must spawn a subagent on a different model family from the one that did the work. Self-review is not a substitute; the point is fresh eyes you cannot bring yourself. The subagent reads the audit trail and the run's transcript, then flags what the user should pay attention to. Not a redo of the work, a scan for what's suboptimal or risky.
+
+- Decisions logged with weak or absent evidence.
+- Verification steps skipped or claimed without proof in the transcript.
+- Choices that look risky in hindsight (premature, scope-creeping, papering over a symptom).
+- Gaps the user would otherwise miss on a casual skim.
+
+Every reply for a run that produced a trail ends with an "Attention" section. Lead with the reviewer's model on its own line (`reviewed by <model>`), then list each flag pointing to specific rows or moments. "No flags" is a valid value; the model name is not. The self-audit asks if the log told the truth; this asks what the user should still scrutinize even when it did.
+
 ## Reviewing the trail
 
 Read top to bottom, follow the evidence pointers, spot-check. GitHub renders a committed TSV as a table; `column -s$'\t' -t decisions.tsv` renders it in a terminal. A row whose evidence doesn't resolve, or whose result is unverified, is the audit catching a gap.


### PR DESCRIPTION
## Summary

Adds a new section to `show-me-your-work` between the self-audit and "Reviewing the trail."

Before handing back, the working agent spawns a subagent on a different model family. It reads the audit trail and the run's transcript, then flags what the user should pay attention to (decisions with weak evidence, skipped verification, risky-in-hindsight choices, blind spots).

Every reply with a trail ends with an "Attention" section that leads with the reviewer's model on its own line, then lists flags. "No flags" is valid; a missing or unnamed model is not. The forcing function makes the absence of a real review observable rather than hide-able behind a fabricated artifact.

Composition pattern matches `interrogate`, `arena`, `eval`. The self-audit asks if the log told the truth; this asks what the user should still scrutinize even when it did.

## Validation

Eval'd over three rounds (3 candidates per round on opus, gpt, composer) on a sync->async migration with a deliberately subtle scope trap (a CLI caller outside the obvious source tree). Iterated the wording from soft suggestion to "must spawn" to "must name the reviewer's model." Each tightening was retested:

- **Round 1** (soft suggestion): 1/3 spawn (opus only).
- **Round 2** (must spawn + Attention forcing function): 2/3 spawn. Caught gpt fabricating "Attention: No flags" without actually reviewing.
- **Round 3** (must name reviewer's model): 1/3 spawn but gpt now drops the artifact rather than fake it; composer honestly discloses when the review didn't run.

When the review fires it produces real signal: pre-existing race conditions, harness weaknesses, scope creep. When it doesn't fire, the model-disclosure requirement makes that visible rather than papered over.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill; no runtime code, auth, or data paths.
> 
> **Overview**
> Inserts a **cross-model review** step into `show-me-your-work` between transcript self-audit and human trail review.
> 
> Agents must spawn a **different model family** subagent to scan the decision TSV and run transcript for user-facing risks (weak evidence, unproven verification, hindsight-risky choices, skim gaps)—not redo the work. Every handback that includes a trail must end with an **Attention** block: `reviewed by <model>` on its own line, then flags (or explicit **No flags**); omitting the reviewer model is disallowed so fake or hollow reviews are visible.
> 
> This complements the existing “did the log tell the truth?” audit with “what should the user still doubt when it did?”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4f94fd25e37d19670a46ca300bb747d73f5236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->