### PR TITLE
pstack: bump version to 0.3.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
## Summary

Bumps the pstack plugin version from `0.2.0` to `0.3.0`.

Since 0.2.0, this release adds:
- New playbooks: refactoring (sharpened "pin behavior contract first" discipline), session-pickup (resume or take over a prior agent's in-flight work), trace-forensics (diagnose a captured profiling artifact, with a transform-to-sqlite step).
- Bug-fix playbook tightened into an explicit binary-search hypothesis loop with synthetic-repro fallback and `/loop`; validated across two blinded evals.
- show-me-your-work gains a cross-model review step that flags what the user should pay attention to, with a reviewer-model-disclosure forcing function (eval-iterated across three rounds).
- New principle: build-the-lever (build the tool that amortizes repetitive work).
- README playbooks now rendered as a table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field metadata change with no runtime, auth, or workflow logic touched in this diff.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin release identifier from `0.2.0` to **`0.3.0`** in `pstack/.cursor-plugin/plugin.json`. This is the only change in the diff: no skills, agents, or playbook content is modified here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4840bf622f6ff86ed449e6579151c84df8e9b2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->