### PR TITLE
pstack: build-the-lever can be a skill your subagents follow

### DIFF
--- a/pstack/skills/principle-build-the-lever/SKILL.md
+++ b/pstack/skills/principle-build-the-lever/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principle-build-the-lever
-description: "Apply when work is repetitive or bulk: many similar edits, a check you'll rerun, a population to transform. Build the tool that amortizes it (codemod, script, generator) once you know the recipe, instead of grinding by hand."
+description: "Apply when work is repetitive or bulk: many similar edits, a check you'll rerun, a population to transform, a fan-out to subagents. Build the tool that amortizes it (codemod, script, generator, or a skill your subagents follow) once you know the recipe, instead of grinding by hand."
 disable-model-invocation: true
 ---
 # Build the Lever
@@ -13,6 +13,7 @@ When the work repeats, build the tool that does it instead of grinding by hand.
 
 - Do the first few by hand to learn the exact recipe, then build the tool. Don't build on a guess.
 - Codemod or script for bulk edits, generator for repetitive files, a dump-to-sqlite query for repeated analysis, a rerunnable check for repeated verification.
+- When you fan work out to subagents, write the lever as a skill they all read: the recipe, the verification contract, and the do-not-touch fences in one artifact, so every delegate inherits the same hardened version instead of re-explaining it per prompt and watching each one drift. Harden it the moment a delegate games or drops the contract, then re-dispatch. Keep it outside the delegates' write scope so they can't quietly edit the contract.
 - Commit it when the work outlives the session, so the next run reruns it instead of redoing it.
 
 **Balance:** Leverage, not gold-plating. The [Laziness Protocol](../principle-laziness-protocol/SKILL.md) still holds. Build the lever only when it pays for itself across the remaining work, never for a one-off.


### PR DESCRIPTION
## Summary

Extends the `principle-build-the-lever` skill with one more form of lever: when you fan work out to subagents, the tool you build can be a skill they all read.

New Pattern bullet: write the recipe, the verification contract, and the do-not-touch fences into one artifact every delegate reads, so they inherit the same hardened version instead of re-explaining it per prompt and watching each drift. Harden it the moment a delegate games or drops the contract, then re-dispatch. Keep it outside the delegates' write scope so they can't quietly edit the contract. The description gains a matching nod (`a skill your subagents follow`).

This is the open-source port of the same change made internally; the wording is identical (no internal references). Distinct from `principle-encode-lessons-in-structure` (a durable guardrail for a recurring instruction): this is throughput on the work in front of you, where the consumers are your delegates and what's amortized is cross-delegate consistency of a verification contract under parallelism.

## Test plan

- [ ] No em-dashes; colon usage is list-only (unslop rule 14).
- [ ] Description stays within the frontmatter token budget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a principle skill; no runtime, auth, or data paths affected.
> 
> **Overview**
> Extends **`principle-build-the-lever`** so a “lever” can be a **shared skill** when work is fanned out to subagents, not only codemods, scripts, or generators.
> 
> The frontmatter **description** now calls out **fan-out to subagents** and **a skill your subagents follow**. A new **Pattern** bullet says to put the recipe, verification contract, and do-not-touch fences in one artifact every delegate reads, harden it if a delegate games or drops the contract, re-dispatch, and keep that artifact **outside** delegates’ write scope so the contract cannot be edited in place. The existing contrast with **`principle-encode-lessons-in-structure`** (durable guardrail vs. throughput on parallel work) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725a62e13e82f499857d80178bd831f02113d089. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->