### PR TITLE
pstack: bump version to 0.4.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
Bumps the pstack plugin version from 0.3.0 to 0.4.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field change with no runtime or behavioral impact.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin release version in `plugin.json` from **0.3.0** to **0.4.0**. No skills, agents, or other plugin metadata change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511f3d147862405b70573f9979c36582d4fbc92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->