### PR TITLE
Fix verify-this skill YAML frontmatter parse error

### DIFF
--- a/cursor-team-kit/skills/verify-this/SKILL.md
+++ b/cursor-team-kit/skills/verify-this/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-this
-description: Verify a claim with fresh local evidence: restate it falsifiably, capture baseline and treatment, compare artifacts, and return VERIFIED, NOT VERIFIED, or INCONCLUSIVE.
+description: "Verify a claim with fresh local evidence: restate it falsifiably, capture baseline and treatment, compare artifacts, and return VERIFIED, NOT VERIFIED, or INCONCLUSIVE."
 ---
 
 # Verify This


### PR DESCRIPTION
## Summary
- Quote the `description` field in `cursor-team-kit/skills/verify-this/SKILL.md` so YAML parsers do not treat `evidence: restate` as a nested mapping.

Fixes #64

## Test plan
- [x] Frontmatter uses a quoted scalar for `description`
- [ ] Skill loads without YAML parse errors in Cursor

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only frontmatter quoting fix with no runtime or security impact.
> 
> **Overview**
> Fixes YAML frontmatter parsing for the **verify-this** skill by wrapping the `description` value in double quotes.
> 
> The unquoted description contained `evidence: restate`, which parsers interpreted as a nested key instead of plain text, breaking skill load. No behavior or workflow content changed—only frontmatter quoting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ae76855a8670d7530cebf0dacd1c252ac5cdea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->