### PR TITLE
pstack: update Opus 4.7 references to 4.8

### DIFF
--- a/pstack/skills/architect/SKILL.md
+++ b/pstack/skills/architect/SKILL.md
@@ -30,7 +30,7 @@ Skip Phase A only when the work is genuinely greenfield with no surrounding syst
 
 Run the **arena** skill with the design-sketch task and the Phase A grounding artifacts as input. Pass `references/runner-prompt.md` as each runner's prompt. Each candidate produces a design package shaped per `references/rationale-template.md`: type sketch, function signatures, module map, and prose rationale.
 
-Use these slugs for the Phase B runners: `claude-opus-4-7-thinking-xhigh`, `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast`, and `composer-2.5-fast`.
+Use these slugs for the Phase B runners: `claude-opus-4-8-thinking-xhigh`, `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast`, and `composer-2.5-fast`.
 
 This is the **exhaust-the-design-space** principle skill made concrete. Whole-shape alternatives, not point fixes inside one shape.
 

--- a/pstack/skills/arena/SKILL.md
+++ b/pstack/skills/arena/SKILL.md
@@ -25,7 +25,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Default 4: `claude-opus-4-7-thinking-xhigh`, `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast`, and `composer-2.5-fast`. Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Default 4: `claude-opus-4-8-thinking-xhigh`, `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast`, and `composer-2.5-fast`. Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out

--- a/pstack/skills/how/SKILL.md
+++ b/pstack/skills/how/SKILL.md
@@ -64,7 +64,7 @@ Then proceed to Step 3.
 Spawn a single Task subagent that explores and explains in one pass:
 
 - `subagent_type`: `generalPurpose`
-- `model`: `claude-opus-4-7-thinking-xhigh`
+- `model`: `claude-opus-4-8-thinking-xhigh`
 - `readonly`: `true`
 
 This agent does its own exploration (Glob, Grep, Read) and writes the explanation directly. Read `references/explainer-prompt.md` for the communication style and output format. The agent follows the same structure, it just doesn't have explorer findings as input.
@@ -76,7 +76,7 @@ Proceed to Step 4.
 Once all explorers have returned, spawn a single Task subagent to synthesize their findings into one coherent explanation:
 
 - `subagent_type`: `generalPurpose`
-- `model`: `claude-opus-4-7-thinking-xhigh`
+- `model`: `claude-opus-4-8-thinking-xhigh`
 - `readonly`: `true`
 
 The explainer gets all explorers' findings and writes the human-facing explanation (see output format below). Read `references/explainer-prompt.md` for the full prompt template. The explainer reconciles overlapping findings, resolves contradictions, and weaves the separate slices into a unified picture.
@@ -113,7 +113,7 @@ After the explanation is complete, spawn architectural critics. Launch all in a 
 
 | Subagent | Model |
 |----------|-------|
-| Critic A | `claude-opus-4-7-thinking-xhigh` |
+| Critic A | `claude-opus-4-8-thinking-xhigh` |
 | Critic B | `gpt-5.3-codex-high-fast` |
 | Critic C | `gpt-5.5-high-fast` |
 

--- a/pstack/skills/interrogate/SKILL.md
+++ b/pstack/skills/interrogate/SKILL.md
@@ -37,7 +37,7 @@ Launch all four in a single message using the Task tool, each with a different m
 
 | Subagent | Model |
 |----------|-------|
-| Reviewer A | `claude-opus-4-7-thinking-xhigh` |
+| Reviewer A | `claude-opus-4-8-thinking-xhigh` |
 | Reviewer B | `gpt-5.3-codex-high-fast` |
 | Reviewer C | `gpt-5.5-high-fast` |
 | Reviewer D | `composer-2.5-fast` |

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -76,7 +76,7 @@ Read the leaf skill in full for any principle you apply.
 
 **Use `subagent_type: "poteto-agent"` for any subagent you spawn directly inside a playbook step** (code-writing delegates, ad-hoc helpers). `/poteto-mode` and `subagent_type: "poteto-agent"` route through the same wrapper. Routed workflow skills (`how`, `why`, `interrogate`, `reflect`) configure their own `subagent_type` for diverse-model review and exploration; respect what the skill prescribes rather than overriding it to `poteto-agent`.
 
-**Defaults for every `Task` call.** `run_in_background: true`, agent mode (readonly strips MCP), file pointers not inlined context, and explicit model (`composer-2.5-fast` for code, `claude-opus-4-7-thinking-xhigh` for prose and judgment).
+**Defaults for every `Task` call.** `run_in_background: true`, agent mode (readonly strips MCP), file pointers not inlined context, and explicit model (`composer-2.5-fast` for code, `claude-opus-4-8-thinking-xhigh` for prose and judgment).
 
 You own every subagent's work. Review the diff and write your own summary; don't pass through what it said. Interrupt-chained resumes silently drop directives, so fire a fresh subagent with consolidated scope rather than trusting a "done" summary. A second opinion is the same prompt against a different model; agreement is high-signal.
 

--- a/pstack/skills/poteto-mode/references/plan.md
+++ b/pstack/skills/poteto-mode/references/plan.md
@@ -25,7 +25,7 @@ Resolve what is in scope vs explicitly out, technical or platform constraints, p
 Delegate codebase exploration (the **guard-the-context-window** principle skill).
 
 - Prefer `subagent_type: "poteto-agent"`. `generalPurpose` is the fallback. Never use the built-in `plan` subagent_type; it ignores this skill.
-- Pass `model:` explicitly. `composer-2.5-fast` for code reads, `claude-opus-4-7-thinking-xhigh` for judgment.
+- Pass `model:` explicitly. `composer-2.5-fast` for code reads, `claude-opus-4-8-thinking-xhigh` for judgment.
 
 Each explorer returns file pointers, conventions, dependencies, test infrastructure, and entry points. No inlined dumps.
 

--- a/pstack/skills/reflect/SKILL.md
+++ b/pstack/skills/reflect/SKILL.md
@@ -38,15 +38,15 @@ One message, three `Task` calls, `subagent_type: generalPurpose`, explicit `mode
 
 | Lens | `model` | Prompt template |
 |---|---|---|
-| Judgment | `claude-opus-4-7-thinking-xhigh` | `references/judgment-reviewer.md` |
+| Judgment | `claude-opus-4-8-thinking-xhigh` | `references/judgment-reviewer.md` |
 | Tooling | `composer-2.5-fast` | `references/tooling-reviewer.md` |
-| Divergent | `claude-opus-4-7-thinking-xhigh` | `references/divergent-reviewer.md` |
+| Divergent | `claude-opus-4-8-thinking-xhigh` | `references/divergent-reviewer.md` |
 
 Pass each template verbatim, substituting the transcript path or digest where marked. Reviewers return findings in the `Task` response body.
 
 ### 3. Synthesize
 
-One `Task` call, `subagent_type: generalPurpose`, `model: claude-opus-4-7-thinking-xhigh`, agent mode (`readonly: false`). The synthesizer's quality check includes spot-verifying citations, which can require MCP access; readonly strips MCPs and defeats that. Use `references/synthesizer.md` verbatim, with each reviewer's full output inlined where marked. The synthesizer returns a structured Accepted / Rejected / Backlog list.
+One `Task` call, `subagent_type: generalPurpose`, `model: claude-opus-4-8-thinking-xhigh`, agent mode (`readonly: false`). The synthesizer's quality check includes spot-verifying citations, which can require MCP access; readonly strips MCPs and defeats that. Use `references/synthesizer.md` verbatim, with each reviewer's full output inlined where marked. The synthesizer returns a structured Accepted / Rejected / Backlog list.
 
 ### 4. Structural enforcement check
 

--- a/pstack/skills/why/SKILL.md
+++ b/pstack/skills/why/SKILL.md
@@ -163,7 +163,7 @@ If your scope assessment suggests a single-commit trivial target where the PR de
 Spawn one synthesizer subagent:
 
 - `subagent_type`: `generalPurpose`
-- `model`: `claude-opus-4-7-thinking-xhigh`
+- `model`: `claude-opus-4-8-thinking-xhigh`
 - `readonly`: `false` (agent mode). The synthesizer's quality check includes spot-verifying citations, which can require MCP access. Readonly/Ask mode strips MCPs and defeats that.
 
 The synthesizer gets:


### PR DESCRIPTION
## Summary

Mechanical find-and-replace updating Opus 4.7 model slug references to Opus 4.8 across `pstack/skills/`. Every match was the model slug `claude-opus-4-7-thinking-xhigh`, updated to `claude-opus-4-8-thinking-xhigh`.

## Scope

Only Opus model slug references were touched. No other version strings were modified — `gpt-5.3-codex-high-fast`, `gpt-5.5-high-fast`, and `composer-2.5-fast` were all left untouched.

## Files changed (8)

- `pstack/skills/architect/SKILL.md`
- `pstack/skills/arena/SKILL.md`
- `pstack/skills/how/SKILL.md`
- `pstack/skills/interrogate/SKILL.md`
- `pstack/skills/poteto-mode/SKILL.md`
- `pstack/skills/poteto-mode/references/plan.md`
- `pstack/skills/reflect/SKILL.md`
- `pstack/skills/why/SKILL.md`

## Test plan

- Markdown-only diff (8 files, 12 lines changed, 12 lines added)
- Verified zero remaining matches for `claude-opus-4-7`, `opus-4.7`, `Opus 4.7` under `pstack/skills/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation of model identifiers; no runtime code, auth, or data paths change. Operational risk is limited to agents failing Task spawn if 4.8 slug is unavailable (interrogate already documents fallback).
> 
> **Overview**
> Updates the prescribed **Claude Opus** Task model slug from `claude-opus-4-7-thinking-xhigh` to `claude-opus-4-8-thinking-xhigh` across eight `pstack/skills/` workflow docs. **GPT** and **Composer** slugs are unchanged.
> 
> The new slug is wired wherever Opus is the default for **judgment, synthesis, explanation, or design** work: **architect** Phase B arena runners; **arena** default runner set; **how** (direct explain, synthesize, critique Critic A); **interrogate** Reviewer A; **poteto-mode** and **plan** defaults for prose/judgment; **reflect** (judgment and divergent reviewers plus synthesizer); **why** synthesizer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24370eebe781d4d8cc12d65e0dce2a1dfed835ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->