### PR TITLE
pstack: interrogate gains a multi-model code-quality lens

### DIFF
--- a/pstack/skills/interrogate/SKILL.md
+++ b/pstack/skills/interrogate/SKILL.md
@@ -53,6 +53,9 @@ Read `references/reviewer-prompt.md` and fill in the template with:
 1. The stated intent
 2. The diff or file contents
 3. The review rubric from `references/rubric.md`
+4. The code-quality lens from `references/code-quality-review.md`
+
+The same filled template goes to all four reviewers, so every model applies the code-quality lens.
 
 Each reviewer produces structured findings as described in the prompt template.
 

--- a/pstack/skills/interrogate/references/code-quality-review.md
+++ b/pstack/skills/interrogate/references/code-quality-review.md
@@ -1,0 +1,47 @@
+# Code Quality Review
+
+Each reviewer applies this code-quality lens in addition to the rubric. It is a strict standard focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this lens should push the reviewer to be ambitious about code structure. Do not merely identify local cleanup. Actively search for "code judo" moves. These are restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Dimensions
+
+Each dimension is stated once. Apply the ones that are relevant.
+
+0. **Be ambitious about structural simplification.** Do not stop at "this could be a bit cleaner." Look for reframings that make whole branches, helpers, modes, conditionals, or layers disappear. Assume a "code judo" move is often available. It uses the existing architecture more effectively and makes the change dramatically simpler. If you can delete complexity rather than rearrange it, push hard for that.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.** Treat this as a strong smell. Prefer extracting helpers, subcomponents, or modules. If the diff crosses that threshold, ask whether the code should be decomposed first. Waive only for a compelling structural reason where the resulting file stays clearly organized.
+
+2. **Do not allow spaghetti growth in existing code.** Be suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows. Treat "weird if statements in random places" as a design problem, not a style nit. Prefer pushing the logic into a dedicated helper, state machine, or module instead of tangling an existing path.
+
+3. **Bias toward cleaning the design, not just accepting working code.** If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version. Prefer simplifications that remove moving pieces over refactors that spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.** Treat brittle, ad-hoc, or "magic" behavior as a problem. Be skeptical of generic mechanisms that hide simple data-shape assumptions. Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push on type and boundary cleanliness when it affects maintainability.** Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist. Prefer explicit typed models over loosely-shaped ad-hoc objects. If a branch leans on a silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.** Call out feature logic leaking into shared paths or implementation details leaking through APIs. Prefer existing canonical utilities over bespoke one-offs. Push code toward the right package, service, or module instead of normalizing drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.** If independent work is serialized for no reason, ask whether it should run in parallel. If related updates can leave state half-applied, push for a more atomic structure. Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the code more brittle.
+
+## Output Expectations
+
+Prioritize structural code-quality regressions and missed simplifications first, then spaghetti and branching complexity, then boundary, type, and file-size concerns, then smaller modularity and legibility issues. Do not flood the review with low-value nits when larger structural issues exist. Prefer a few high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct. Treat these as presumptive blockers unless the author can justify them. The PR keeps a lot of incidental complexity when a code-judo move would delete it. The PR pushes a file from below 1000 lines to above 1000 lines. The PR adds ad-hoc branching that tangles an existing flow. The PR scatters feature checks across shared code. The PR adds an unnecessary abstraction, wrapper, or cast-heavy contract. The PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home. If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality. Do not be rude, but do not soften major maintainability issues into mild suggestions. If the code is making the codebase messier, say so. If the implementation missed an obvious dramatic simplification, say that too. Do not be satisfied with "maybe rename this" when the real issue is structural.

--- a/pstack/skills/interrogate/references/reviewer-prompt.md
+++ b/pstack/skills/interrogate/references/reviewer-prompt.md
@@ -22,9 +22,13 @@ You are reviewing whether the code achieves this intent well. Do NOT question th
 
 {RUBRIC_CONTENTS}
 
+## Code Quality Lens
+
+{CODE_QUALITY_CONTENTS}
+
 ## Instructions
 
-Review the code through every lens in the rubric that you find relevant. Do not force yourself through lenses that don't apply. If the code is a simple bug fix, you don't need to write paragraphs about architectural integrity.
+Review the code through every lens in the rubric and the code-quality lens above that you find relevant. Do not force yourself through lenses that don't apply. If the code is a simple bug fix, you don't need to write paragraphs about architectural integrity.
 
 For each finding, provide:
 


### PR DESCRIPTION
interrogate now feeds a code-quality lens (references/code-quality-review.md) to all four reviewer models alongside the rubric. The lens carries opinionated standards the rubric does not already cover: a ~1000-line file-size threshold, spaghetti-branching growth, type and cast honesty at boundaries, canonical-layer reuse, non-atomic orchestration smells, and ambitious behavior-preserving simplification. The reference was validated with a planted-defect eval across multiple trim levels; this is the smallest version that kept every planted dimension at full panel recall with zero decoy false positives. Wiring: a Code Quality Lens placeholder in reviewer-prompt.md and one extra item in the SKILL.md step that fills the reviewer template. Severity stays on the existing critical/warning/nit scale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill prompt wiring only; no production code paths or security-sensitive runtime changes.
> 
> **Overview**
> The **interrogate** skill now injects a dedicated **code-quality lens** into every adversarial review, alongside the existing rubric.
> 
> A new reference, `references/code-quality-review.md`, defines a stricter maintainability standard: behavior-preserving “code judo” simplification, a ~1k-line file-size guardrail, anti-spaghetti branching, type/boundary hygiene, canonical-layer reuse, and orchestration/atomicity smells, plus output prioritization and a higher approval bar. `SKILL.md` Step 3 now requires filling that document into the reviewer template so all four models share the same lens. `reviewer-prompt.md` adds a `{CODE_QUALITY_CONTENTS}` section and tells reviewers to apply both the rubric and the code-quality lens where relevant.
> 
> No application runtime or API behavior changes—only review prompt wiring and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f2db6550b51e7c51ec8e1c9288ab59c7255439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->