### PR TITLE
pstack: bump version to 0.5.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
Bumps the pstack plugin version from 0.4.0 to 0.5.0 for the latest batch of skill additions (build-the-lever subagent-skills note, architect usage-first design, interrogate multi-model code-quality lens, Opus 4.8 model references).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 65bb2fbd7771a5c24704af3696735c93db9a146c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->