### PR TITLE
pstack: build-the-lever defaults to building the tool for any non-trivial work

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -38,7 +38,7 @@ Read the leaf skill in full for any principle you apply.
 - **Outcome-Oriented Execution.** The **principle-outcome-oriented-execution** skill. Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't preserve throwaway compatibility states.
 - **Experience First.** The **principle-experience-first** skill. Apply on product, UX, or feature-scope tradeoffs. Choose user delight over implementation convenience.
 - **Exhaust the Design Space.** The **principle-exhaust-the-design-space** skill. Apply on a novel interaction or architectural decision with no precedent. Build 2-3 competing prototypes and compare before committing.
-- **Build the Lever.** The **principle-build-the-lever** skill. Apply when work is repetitive or bulk. Build the tool that amortizes it (codemod, script, generator) once you know the recipe, instead of grinding by hand.
+- **Build the Lever.** The **principle-build-the-lever** skill. Apply to any non-trivial work. Build the tool that does it or proves it (codemod, script, generator) instead of working by hand; the tool is the artifact a reviewer can rerun.
 
 **Architecture**
 

--- a/pstack/skills/principle-build-the-lever/SKILL.md
+++ b/pstack/skills/principle-build-the-lever/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: principle-build-the-lever
-description: "Apply when work is repetitive or bulk: many similar edits, a check you'll rerun, a population to transform, a fan-out to subagents. Build the tool that amortizes it (codemod, script, generator, or a skill your subagents follow) once you know the recipe, instead of grinding by hand."
+description: "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or proves it (codemod, script, generator, or a skill your subagents follow) instead of working by hand. The tool is the artifact a reviewer can rerun."
 disable-model-invocation: true
 ---
 # Build the Lever
 
-When the work repeats, build the tool that does it instead of grinding by hand.
+When the work isn't trivial, build the tool that does it instead of doing it by hand.
 
-**Why:** Doing the same edit a hundred times is slow and drifts into inconsistent mistakes. A codemod, generator, or script does it once, the same way every time, reruns for free, and gives a reviewer one artifact to check.
+**Why:** Two payoffs. Throughput: a codemod, generator, or script does the work the same way every time and reruns for free. Confidence: the tool is one artifact a reviewer can read and rerun to check the work. Hand-done changes can only be re-verified by redoing them. A deterministic script turns "trust me" into "run this".
 
-**Pattern:** When you would otherwise repeat a transform, a check, or a setup more than a handful of times, build the lever instead.
+**Pattern:** Default to building the lever. Skip it only when the task is genuinely trivial, a couple of obvious edits you can see at a glance.
 
-- Do the first few by hand to learn the exact recipe, then build the tool. Don't build on a guess.
-- Codemod or script for bulk edits, generator for repetitive files, a dump-to-sqlite query for repeated analysis, a rerunnable check for repeated verification.
-- When you fan work out to subagents, write the lever as a skill they all read: the recipe, the verification contract, and the do-not-touch fences in one artifact, so every delegate inherits the same hardened version instead of re-explaining it per prompt and watching each one drift. Harden it the moment a delegate games or drops the contract, then re-dispatch. Keep it outside the delegates' write scope so they can't quietly edit the contract.
-- Commit it when the work outlives the session, so the next run reruns it instead of redoing it.
+- Do the first unit by hand to learn the recipe, then build the tool. Prove it by rerunning it on that unit and diffing against your hand-done version. Make the lever safe to rerun. A reviewer will.
+- Codemod or script for edits, generator for repetitive files, a dump-to-sqlite query for analysis, a rerunnable check for verification.
+- A deterministic lever beats fan-out. If the tool can process every unit in one pass, run it yourself; don't fan out delegates to hand-apply what a script can do.
+- When you fan work out to subagents, write the lever as a skill they all read: the recipe, the verification contract, and the do-not-touch fences in one artifact, so every delegate inherits the same hardened version instead of re-explaining it per prompt and watching each one drift. Keep it outside the delegates' write scope so they can't quietly edit the contract.
+- Applying this principle produces a file. If you cited it and there is no codemod, script, generator, or delegate skill in the diff, you didn't apply it.
+- Commit the lever when the work outlives the session, so the next run reruns it instead of redoing it.
 
-**Balance:** Leverage, not gold-plating. The [Laziness Protocol](../principle-laziness-protocol/SKILL.md) still holds. Build the lever only when it pays for itself across the remaining work, never for a one-off.
+**Balance:** The bar is triviality, not repetition. A one-off still earns a lever when the lever is what makes the work checkable. Leverage, not gold-plating, per the [Laziness Protocol](../principle-laziness-protocol/SKILL.md): the smallest script that does or proves the job, never a framework.
 
-Distinct from [Encode Lessons in Structure](../principle-encode-lessons-in-structure/SKILL.md), which makes a recurring instruction a durable guardrail. This is throughput on the work in front of you.
+Distinct from [Encode Lessons in Structure](../principle-encode-lessons-in-structure/SKILL.md), which makes a recurring instruction a durable guardrail. This is throughput and reviewability on the work in front of you. For scripting the verification itself, see [Prove It Works](../principle-prove-it-works/SKILL.md).

--- a/pstack/skills/principle-build-the-lever/SKILL.md
+++ b/pstack/skills/principle-build-the-lever/SKILL.md
@@ -18,6 +18,6 @@ When the work isn't trivial, build the tool that does it instead of doing it by 
 - Applying this principle produces a file. If you cited it and there is no codemod, script, generator, or delegate skill in the diff, you didn't apply it.
 - Commit the lever when the work outlives the session, so the next run reruns it instead of redoing it.
 
-**Balance:** The bar is triviality, not repetition. A one-off still earns a lever when the lever is what makes the work checkable. Leverage, not gold-plating, per the [Laziness Protocol](../principle-laziness-protocol/SKILL.md): the smallest script that does or proves the job, never a framework.
+**Balance:** The bar is triviality, not repetition. A one-off still earns a lever when the lever is what makes the work checkable. Per the [Laziness Protocol](../principle-laziness-protocol/SKILL.md), build the smallest script that does or proves the job, never a framework.
 
 Distinct from [Encode Lessons in Structure](../principle-encode-lessons-in-structure/SKILL.md), which makes a recurring instruction a durable guardrail. This is throughput and reviewability on the work in front of you. For scripting the verification itself, see [Prove It Works](../principle-prove-it-works/SKILL.md).

--- a/pstack/skills/unslop/SKILL.md
+++ b/pstack/skills/unslop/SKILL.md
@@ -69,7 +69,7 @@ Removing patterns is half the job. Sterile, voiceless writing is just as obvious
 
 ### Jargon
 
-26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". Pick the concrete word.
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". Pick the concrete word.
 
 ### Plain speech
 


### PR DESCRIPTION
The principle's bar moves from repetition to triviality. Build the tool that does or proves the work for any non-trivial task, even a one-off, because the tool is the artifact a reviewer can rerun to gain confidence.

Balance keeps the laziness guard (smallest script that does or proves the job, never a framework) but drops the never-for-a-one-off rule.

New bullets: a deterministic lever beats fan-out; applying the principle produces a file; make the lever safe to rerun. The poteto-mode index line is updated to match.

Validated with a blinded A/B eval (18 runs, 3 tasks, 3 models): on a small one-off data change the new wording took committed rerunnable levers from 0/3 to 2/3 and blinded reviewer-confidence scores from 2.0 to 3.3 mean, with zero over-triggering on a trivial-task guard and no correctness change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to agent skills and style guidance; no runtime, auth, or data paths.
> 
> **Overview**
> **Build the Lever** is reframed from “repetitive or bulk work” to **any non-trivial work**, including one-offs, because the lever is what a reviewer can **read and rerun** for confidence—not only throughput.
> 
> The skill text now **defaults to building a lever** (skip only genuinely trivial edits), requires **proving** the tool on the first unit via rerun/diff, prefers a **deterministic script over subagent fan-out**, and states that citing the principle without a codemod/script/generator/delegate skill in the diff means it wasn’t applied. **Balance** shifts from “pays across remaining work” to “bar is triviality,” while still pointing to the smallest script per Laziness Protocol; it cross-links **Prove It Works** for verification scripting.
> 
> **poteto-mode**’s index bullet for this principle is updated to match. **unslop** adds *gold-plating* to the abstract-metaphor-noun list with a plain-word fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa9323e6103aff474cabb521d574db63ab3a7ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->