### PR TITLE
pstack: frame reply impact for the consumer and the maintainer

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -88,6 +88,7 @@ Write the reply clean as you draft it. Don't write slop and strip it afterward. 
 - **The long-dash character is banned outright.** Two cases we keep catching. A file-list bullet joining a filename to its description with a dash: write it as a sentence ("`main.js` owns persistence and the IPC handlers"), not the dash form. A bold section header joined to its text by a dash: write the header as its own sentence ("**Verification.** End to end via CDP"), not the one-line dash form.
 - **A colon as a mid-sentence connector is also out** (unslop rule 14). A colon before a list is fine.
 - **Terse is not an excuse to drop content.** Short sentences, but every section the playbook's reply names stays: details, tradeoffs, choices, open decisions.
+- **Frame impact for the consumer and the maintainer.** Name who the work is for (an end user, a colleague importing the library) and say what changes for them before any implementation detail. Then say what the next engineer who owns this code inherits. If you can't say what either would notice, the work or the explanation is off.
 - **Never fabricate a link, citation, or transcript reference.** Link only artifacts you actually produced or read this session.
 
 Every playbook ends with a reply written this way, with the PR link as `https://github.com/<owner>/<repo>/pull/<number>`. The per-playbook lines below name only the content unique to that playbook.

--- a/pstack/skills/principle-experience-first/SKILL.md
+++ b/pstack/skills/principle-experience-first/SKILL.md
@@ -14,4 +14,6 @@ The product is the experience. Every technical decision either helps or hurts it
 - Sweat the details (transitions, alignment, spacing, feedback, error states)
 - Tighten the core loop (every feature should serve the central workflow or get out of the way)
 
+The user is whoever consumes the work. For a UI that is the end user. For a library or an internal API it is the colleague who imports it. The engineer who maintains the code next is a user too. Weigh their experience the same way, and explain impact from their seat.
+
 Foundations should serve the experience, not the other way around. Foundational thinking governs the *sequence* of work; this principle governs the *target*.


### PR DESCRIPTION
poteto-mode replies now name who the work is for (an end user or a colleague importing the library) and what changes for them before implementation detail, plus what the next maintainer inherits. experience-first gains a paragraph generalizing the user to whoever consumes the work, including the next maintainer. Validated with a blinded A/B eval (16 runs, 2 tasks, 4 models): blinded consumer-framing scores rose 2.6 to 4.0 and explicit maintainer coverage rose 0/8 to 5/8, with no increase in reply length or padding and no correctness change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent SKILL.md guidance; no production code, auth, or data paths affected.
> 
> **Overview**
> This PR tightens **how poteto-mode agents explain outcomes** by encoding consumer and maintainer framing in skill text, not application code.
> 
> **`poteto-mode/SKILL.md`** adds a **Writing the reply** bullet: name who the work is for (end user vs library consumer), state what changes for them **before** implementation detail, then what the next owner inherits. If neither audience would notice a difference, the reply or the work is considered off.
> 
> **`principle-experience-first/SKILL.md`** broadens “user” to **whoever consumes the work** (UI user, importer of a library/API, and the next maintainer) and requires weighing and explaining impact from their seat.
> 
> No runtime, API, or security surface changes—only agent guidance aligned with an A/B eval noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109f8c3ad54eb1cbaf4efa983c2ec212f562ac73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->