### PR TITLE
pstack: bump to 0.6.0 and refresh README

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -60,6 +60,8 @@ the full rules and playbooks live in `skills/poteto-mode/SKILL.md`.
 
 `/poteto-mode` works extremely well with cursor's `/loop` command. you can make cursor work for many hours without sacrificing rigor.
 
+## skills
+
 the rest are useful when you want to specifically invoke them:
 
 | skill | use it when |

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -54,7 +54,7 @@ when invoked it:
 1. opens a todo list. the first item is reading the inline principles index in the skill.
 2. matches your task to a playbook and copies the steps in verbatim.
 3. routes to the other skills as the steps fire.
-4. writes unslopped replies.
+4. writes unslopped replies framed for the consumer and the maintainer.
 
 the full rules and playbooks live in `skills/poteto-mode/SKILL.md`.
 
@@ -67,9 +67,9 @@ the rest are useful when you want to specifically invoke them:
 | `/poteto-mode` | default entry point for any non-trivial task. |
 | `/how` | you want a walkthrough of how a subsystem works. |
 | `/why` | you want to know why something was built this way. discovers available MCPs at run time and queries each evidence category in parallel (source control, issue tracker, long-form docs, real-time chat, infra observability, error tracking, analytics warehouse). |
-| `/architect` | you're about to write code that crosses a function boundary and want the types and module shape settled first. |
+| `/architect` | you're about to write code that crosses a function boundary and want the caller's usage, types, and module shape settled first. |
 | `/arena` | you want N parallel attempts at the same thing, then to grab the best parts of each. |
-| `/interrogate` | you have a diff and want four different models to try to break it. |
+| `/interrogate` | you have a diff and want four different models to try to break it, including a strict code-quality lens. |
 | `/automate-me` | you want your own `-mode` skill, drafted from how you've actually worked. |
 | `/reflect` | a long task landed and you want the recipe captured as a skill edit. |
 | `/tdd` | you're fixing a bug and there's a cheap local test path. write the failing test first, then the fix. |


### PR DESCRIPTION
bumps pstack from 0.5.0 to 0.6.0 for the recent batch of skill changes (build-the-lever now defaults to building a rerunnable tool for any non-trivial work, architect designs from the caller's usage first, interrogate gained a code-quality lens applied by all four reviewer models, replies are framed for the consumer and the maintainer, Opus references updated to 4.8). README updated to match: reply framing line, architect row, interrogate row.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump and documentation-only README changes; no runtime or application code paths are modified in this diff.
> 
> **Overview**
> **Release 0.6.0** bumps `plugin.json` from `0.5.0` to `0.6.0` and aligns the README with the latest skill behavior (the substantive skill edits ship outside this diff).
> 
> The **poteto-mode** flow now documents that step 4 produces replies **framed for the consumer and the maintainer**, not only “unslopped” text. A **## skills** heading was added before the skills table.
> 
> README rows were tightened for **`/architect`** (caller’s usage first, then types and module shape) and **`/interrogate`** (four models plus a **strict code-quality lens**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5d046155bf082c6d3b94f2e8152ab292fc818a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->