### PR TITLE
fix: match root planner by exact name in kickoff dedupe

### DIFF
--- a/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
@@ -75,6 +75,34 @@ describe("kickoff dedupe", () => {
     expect(active).toBeNull();
   });
 
+  test("does not adopt a planner whose slug only shares a prefix", async () => {
+    const now = Date.parse("2026-05-01T16:00:00.000Z");
+    // An active planner for the distinct goal "refactor-ui" (named
+    // "refactor-ui-root") must not be adopted when kicking off goal "refactor":
+    // "refactor-ui-root".startsWith("refactor") is true, so a bare prefix match
+    // would silently attach the new run to the wrong goal's planner.
+    const active = await findActiveRootPlanner(
+      {
+        async list() {
+          return {
+            items: [
+              {
+                agentId: "bc-refactor-ui",
+                name: "refactor-ui-root",
+                createdAt: now - 1_000,
+                latestRun: { id: "run-refactor-ui", status: "running" },
+              },
+            ],
+          };
+        },
+      },
+      "refactor",
+      now
+    );
+
+    expect(active).toBeNull();
+  });
+
   test("falls back to listRuns when list omits latest run", async () => {
     const now = Date.parse("2026-05-01T16:00:00.000Z");
     const active = await findActiveRootPlanner(

--- a/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
@@ -77,10 +77,6 @@ describe("kickoff dedupe", () => {
 
   test("does not adopt a planner whose slug only shares a prefix", async () => {
     const now = Date.parse("2026-05-01T16:00:00.000Z");
-    // An active planner for the distinct goal "refactor-ui" (named
-    // "refactor-ui-root") must not be adopted when kicking off goal "refactor":
-    // "refactor-ui-root".startsWith("refactor") is true, so a bare prefix match
-    // would silently attach the new run to the wrong goal's planner.
     const active = await findActiveRootPlanner(
       {
         async list() {

--- a/orchestrate/skills/orchestrate/scripts/cli/task.ts
+++ b/orchestrate/skills/orchestrate/scripts/cli/task.ts
@@ -478,11 +478,8 @@ export async function findActiveRootPlanner(
   nowMs: number = Date.now()
 ): Promise<ActiveRootPlanner | null> {
   const list = await agentApi.list({ runtime: "cloud", limit: 50 });
-  // Kickoff names the root planner exactly `${rootSlug}-root` (see the
-  // `kickoff` action). Match that full name, not a bare `startsWith(rootSlug)`
-  // prefix — otherwise slug `auth` would adopt an unrelated `auth-ui-root`
-  // planner because `"auth-ui-root".startsWith("auth")` is true, silently
-  // attaching a fresh run to a different goal's planner.
+  // Exact match, not startsWith: a prefix slug would otherwise adopt another
+  // goal's `<slug>-root` planner (e.g. "auth" adopting "auth-ui-root").
   const rootPlannerName = `${rootSlug}-root`;
   for (const item of listItems(list)) {
     const name = stringField(item, "name");

--- a/orchestrate/skills/orchestrate/scripts/cli/task.ts
+++ b/orchestrate/skills/orchestrate/scripts/cli/task.ts
@@ -478,10 +478,16 @@ export async function findActiveRootPlanner(
   nowMs: number = Date.now()
 ): Promise<ActiveRootPlanner | null> {
   const list = await agentApi.list({ runtime: "cloud", limit: 50 });
+  // Kickoff names the root planner exactly `${rootSlug}-root` (see the
+  // `kickoff` action). Match that full name, not a bare `startsWith(rootSlug)`
+  // prefix — otherwise slug `auth` would adopt an unrelated `auth-ui-root`
+  // planner because `"auth-ui-root".startsWith("auth")` is true, silently
+  // attaching a fresh run to a different goal's planner.
+  const rootPlannerName = `${rootSlug}-root`;
   for (const item of listItems(list)) {
     const name = stringField(item, "name");
     if (!name) continue;
-    if (!name.startsWith(rootSlug)) continue;
+    if (name !== rootPlannerName) continue;
     const createdAt = timeMs(field(item, "createdAt"));
     if (createdAt === null || nowMs - createdAt > MAX_BOOT_MS) continue;
     const agentId =


### PR DESCRIPTION
## Problem

`orchestrate kickoff` is meant to be idempotent: if a recent root planner for the *same* goal is already running, it adopts that agent instead of spawning a duplicate. But the dedupe in `findActiveRootPlanner` adopts an active planner belonging to a **different** goal when one slug is a prefix of another.

Kicking off goal `auth` while a planner for goal `auth-ui` (agent named `auth-ui-root`) is active prints `adopting <auth-ui agent>` and attaches the new run to the wrong goal's planner. The intended `auth` run never starts, and the operator silently lands in an unrelated orchestration.

## Root cause

The kickoff action names every root planner deterministically as `` `${rootSlug}-root` `` (`cli/task.ts`), but the dedupe scan matched with a bare prefix check:

```ts
if (!name.startsWith(rootSlug)) continue;
```

`"auth-ui-root".startsWith("auth")` is `true`, so a slug that is a prefix of another goal's slug collides. Non-root task agents use a different scheme (`` `${rootSlug}/${name}` ``), so only root planners are affected — but any two goals where one slug prefixes the other will cross-adopt.

## Fix

Match the canonical planner name exactly. Since the name is fully deterministic, exact equality is both correct and the tightest possible check:

```ts
const rootPlannerName = `${rootSlug}-root`;
...
if (name !== rootPlannerName) continue;
```

Surgical, one-line behavioral change plus a clarifying comment. No other call sites or naming paths are touched.

## Test

Added a regression test to `__tests__/kickoff-dedupe.test.ts`: an active `refactor-ui-root` planner must **not** be adopted when kicking off slug `refactor` (prefix overlap), asserting `findActiveRootPlanner(...)` returns `null`.

- **Fail-before:** with the original `startsWith` check, the new test fails — `findActiveRootPlanner` returns the unrelated `bc-refactor-ui` agent instead of `null`.
- **Pass-after:** with the exact-match fix, the new test passes.
- Full suite green: `bun test` → 208 pass / 0 fail; `tsc --noEmit` clean.

## Repro

```ts
import { findActiveRootPlanner } from "./cli/task.ts";

// Active planner for goal "auth-ui"; we kick off the distinct goal "auth".
const r = await findActiveRootPlanner(
  { async list() { return { items: [{
      agentId: "bc-authui",
      name: "auth-ui-root",
      createdAt: Date.now() - 1_000,
      latestRun: { id: "run-authui", status: "running" },
  }] }; } },
  "auth",
);
// before fix: r.agentId === "bc-authui"  (wrong goal adopted)
// after  fix: r === null                 (no match; a new planner is spawned)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in kickoff idempotency with a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> **Fixes kickoff dedupe** so `orchestrate kickoff` only adopts a running root planner for the *same* goal, not a different goal whose slug happens to prefix yours.
> 
> `findActiveRootPlanner` now matches the canonical agent name `` `${rootSlug}-root` `` with **equality** instead of `name.startsWith(rootSlug)`. That stops cases like kicking off `auth` from silently adopting an active `auth-ui-root` planner and skipping the intended run.
> 
> A regression test asserts that an active `refactor-ui-root` planner is **not** adopted when looking up slug `refactor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2194be47d6372a494e841290425d43887ef2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->