### PR TITLE
pstack: fold enforcement-strength rung into encode-lessons-in-structure

### DIFF
--- a/pstack/skills/principle-encode-lessons-in-structure/SKILL.md
+++ b/pstack/skills/principle-encode-lessons-in-structure/SKILL.md
@@ -16,6 +16,8 @@ When you catch yourself writing the same instruction a second time:
 2. If yes, encode it. Delete the instruction
 3. If no (genuinely requires judgment), make the instruction more prominent and add an example of the failure mode
 
+**Pick the strongest rung.** When more than one mechanism would work, choose the strongest the situation allows (an unrepresentable state that cannot compile, then a lint or banned API that fails CI, then a canonical helper, then a runtime check), because agents copy whatever the surrounding code already does and a weaker guard becomes the next template.
+
 **Corollary:** Don't paper over symptoms. If the fix is structural, ONLY use the structural fix. The instruction IS the symptom.
 
 **Feedback loop:**


### PR DESCRIPTION
## Summary
- Adds one sentence to `principle-encode-lessons-in-structure` that ranks enforcement mechanisms by strength: prefer an unrepresentable/compile-time guard, then a lint or banned API that fails CI, then a canonical helper, then a runtime check, because agents copy whatever the surrounding code already does and a weaker guard becomes the next template.
- This came out of A/B evaluation: a proposed standalone "enforce, don't advise" principle showed no behavioral lift over the existing principle, so its one non-redundant idea (the strength ladder) is folded in here instead of adding a separate principle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill; no runtime, auth, or application code.
> 
> **Overview**
> Extends **`principle-encode-lessons-in-structure`** with a **Pick the strongest rung** rule: when several structural fixes fit, prefer the strongest option the situation allows—unrepresentable/compile-time guard, then lint or banned API (CI), then canonical helper, then runtime check—because agents tend to copy surrounding patterns and a weaker guard becomes the template.
> 
> This folds the only non-redundant idea from a proposed standalone “enforce, don’t advise” principle (dropped after A/B showed no extra lift) instead of adding another principle file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be35a6f33fe5c2df4cf31625ce1395a558f4dd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->