### PR TITLE
pstack: add pause-safely playbook

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -116,5 +116,6 @@ A large or cross-cutting effort (a migration across many call sites, an ambitiou
 - **Eval.** Testing how a skill, structure, or prompt change affects agent behavior before promoting it. `playbooks/eval.md`.
 - **Autonomous run.** A long task to drive to completion without stopping ("run until done", "/loop until X"). `playbooks/autonomous-run.md`.
 - **Session pickup.** Resuming or taking over a prior agent's in-flight work from a transcript, cloud-agent URL, or pushed branch. `playbooks/session-pickup.md`.
+- **Pause safely.** Suspending in-flight work cleanly so it can be resumed, on an explicit pause, going offline, a Cursor restart, or imminent context compaction. The complement to Session pickup. Full steps: `playbooks/pause-safely.md`.
 - **Multi-phase or multi-PR plan.** Work that spans phases or stacked PRs. `playbooks/multi-phase-plan.md`.
 - **Opening a PR.** Invoked at the end of every other playbook. `playbooks/opening-a-pr.md`.

--- a/pstack/skills/poteto-mode/playbooks/pause-safely.md
+++ b/pstack/skills/poteto-mode/playbooks/pause-safely.md
@@ -1,0 +1,10 @@
+### Pause safely
+
+**You own a clean stop. Leave a checkpoint a cold-start agent can resume from.** For "pause safely", "I need to go offline", "restart Cursor", or "board my flight", and when context is about to compact or summarize. This is explicit only. On "keep going", "going to bed, keep going", or "don't stop", do not pause. Those mean continue, and Autonomous run already checkpoints per iteration.
+
+1. Stop at a safe boundary. Finish the current atomic step or back out of it. Never stop mid-edit in a known-broken state. Start nothing new, and cancel any nested subagents.
+2. Don't cross an irreversible line to pause. No PR and no push unless you already had one out.
+3. Make the work durable. Commit uncommitted edits as one clear `wip:` commit on the current branch so nothing is lost. If the tree is broken, say so in the commit body in one line.
+4. Write the resume note off-context. Capture intent, what you were doing, progress and what's verified, current state, next steps, key files, and gotchas. For the compaction trigger write it to a file like `/tmp/<slug>-resume.md`, because the in-context plan won't survive summarization. If a show-me-your-work trail exists, point at it instead of duplicating it.
+
+**Reply:** where you are in the loop, what's on disk versus still in your head (paths, no diff dumps), the commits you made and whether the tree is clean, and the first action on resume. This is a pause, not a final report. Resume is the Session pickup playbook reading this note.


### PR DESCRIPTION
## Summary
- Adds a `pause-safely` playbook: a clean-checkpoint contract for suspending in-flight work (explicit pause, going offline, restarting, or imminent context compaction) so a cold-start agent can resume from it. The complement to the existing Session pickup playbook.
- Explicit-only with guards so it does not fire on "keep going". Validated by an A/B eval: with the playbook, agents leave a durable `wip:` checkpoint and a resume note instead of leaving the tree dirty, with no over-triggering on "keep going".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill/playbook changes with no runtime or application code impact.
> 
> **Overview**
> Adds a **Pause safely** playbook to poteto-mode as the complement to **Session pickup**: agents get an explicit contract for stopping mid-task without losing work.
> 
> `SKILL.md` lists the new playbook (explicit pause, offline, Cursor restart, or imminent compaction; not on "keep going"). `playbooks/pause-safely.md` defines four steps: stop at a safe boundary, avoid new PR/push, `wip:` commit for durability, and an off-context resume note (e.g. `/tmp/<slug>-resume.md` before compaction). Resume is delegated to Session pickup via that note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3433b582137fb64ac18857fde9c4f1cd074708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->