### PR TITLE
pstack: bump version to 0.7.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
Routine minor bump for the skill changes landed since 0.6.0: concision passes across how / why / interrogate / architect, the pause-safely playbook, and the skeptical-reviewer trigger plus arena routing in the feature flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no runtime or behavioral impact in this PR.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin release version in `plugin.json` from **0.6.0** to **0.7.0**. No other manifest fields, paths, or bundled assets change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9794dfda4ef0278b9f9e4fccd8e6916540421952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->