### PR TITLE
orchestrate: stuck-escalation badge + per-viewer start time, opus 4.8, @cursor/sdk 1.0.12

### DIFF
--- a/orchestrate/skills/orchestrate/references/dispatcher.md
+++ b/orchestrate/skills/orchestrate/references/dispatcher.md
@@ -13,7 +13,7 @@ The dispatcher is one-shot. Take the user's goal, launch a cloud root planner vi
 One-time setup: run `bun install` inside this skill's `scripts/` directory if `node_modules/` is missing. The scripts live outside the host repo's package manager workspace on purpose.
 
 ```bash
-bun cli.ts kickoff "<goal>" [--repo <url>] [--ref main] [--model claude-opus-4-7] [--slack-channel C123] [--dispatcher-name "Alex"]
+bun cli.ts kickoff "<goal>" [--repo <url>] [--ref main] [--model claude-opus-4-8] [--slack-channel C123] [--dispatcher-name "Alex"]
 ```
 
 The CLI reads `CURSOR_API_KEY`, auto-detects the repo from `git config --get remote.origin.url`, builds the spawn prompt, spawns via `cursor-sdk`, and prints `{ agentId, runId, status, url, dispatcherFirstName }` JSON. Slack is optional. If `SLACK_BOT_TOKEN` is set, also pass `--slack-channel <id>` or set `SLACK_CHANNEL_ID`; otherwise kickoff fails before spawning. If the token is unset, Slack stays disabled.

--- a/orchestrate/skills/orchestrate/scripts/__tests__/agent-manager-slack-mirror.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/agent-manager-slack-mirror.test.ts
@@ -2,14 +2,14 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-const TEST_SLACK_CHANNEL = "C123TEST";
 import type { State } from "../schemas.ts";
 import {
   installSlackWebApiMock,
   resetSlackWebApiMock,
   slackWebApiCalls,
 } from "./support/slack-web-api-mock.ts";
+
+const TEST_SLACK_CHANNEL = "C123TEST";
 
 installSlackWebApiMock();
 
@@ -54,6 +54,12 @@ async function waitFor(predicate: () => boolean, label: string): Promise<void> {
   throw new Error(`timed out waiting for ${label}`);
 }
 
+function formatStartedSlackDirective(d: Date): string {
+  const epoch = Math.floor(d.getTime() / 1000);
+  const fallback = d.toISOString().replace(/\.\d{3}Z$/, "Z");
+  return `<!date^${epoch}^{ago}|${fallback}>`;
+}
+
 describe("AgentManager Slack status mirror", () => {
   test("Creates a task thread message then edits it in place", async () => {
     const workspace = mkdtempSync(join(tmpdir(), "orch-slack-mirror-"));
@@ -89,10 +95,11 @@ describe("AgentManager Slack status mirror", () => {
       const mgr = await AgentManager.load(workspace);
       const task = requireTask(mgr.getTask("worker-one"), "worker-one");
 
+      const startedAt = new Date(Date.now() - 2 * 60_000).toISOString();
       mgr.touch(task, {
         agentId: "bc-child",
         status: "running",
-        startedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+        startedAt,
       });
       await waitFor(
         () => readState(workspace).tasks[0]?.slackTs === "222.333",
@@ -114,7 +121,7 @@ describe("AgentManager Slack status mirror", () => {
         channel: TEST_SLACK_CHANNEL,
         thread_ts: "111.222",
         username: "worker-one",
-        text: "▶︎ running\nstarted 2m ago · <https://cursor.com/agents/bc-child|view>",
+        text: `▶︎ running\nstarted ${formatStartedSlackDirective(new Date(startedAt))} · <https://cursor.com/agents/bc-child|view>`,
       });
       expect(calls[0].args.icon_emoji).toBeUndefined();
       expect(calls[1].args).toMatchObject({
@@ -184,7 +191,9 @@ describe("AgentManager Slack status mirror", () => {
   });
 
   test("Child planner load does not create a top-level kickoff", async () => {
-    const workspace = mkdtempSync(join(tmpdir(), "orch-slack-child-no-kickoff-"));
+    const workspace = mkdtempSync(
+      join(tmpdir(), "orch-slack-child-no-kickoff-")
+    );
     resetSlackWebApiMock(() => {
       throw new Error("child planner should not post kickoff");
     });
@@ -227,7 +236,9 @@ describe("AgentManager Slack status mirror", () => {
   });
 
   test("Child planner load fails when kickoff ref is missing", async () => {
-    const workspace = mkdtempSync(join(tmpdir(), "orch-slack-child-missing-ref-"));
+    const workspace = mkdtempSync(
+      join(tmpdir(), "orch-slack-child-missing-ref-")
+    );
     resetSlackWebApiMock(() => {
       throw new Error("child planner should not post kickoff");
     });
@@ -320,7 +331,7 @@ describe("AgentManager Slack status mirror", () => {
         call => call.method === "chat.update"
       );
       expect(update?.args.text).toBe(
-        "▶︎ running\nstarted 0m ago · <https://cursor.com/agents/bc-child|view>"
+        "▶︎ running\nstarted just now · <https://cursor.com/agents/bc-child|view>"
       );
     } finally {
       rmSync(workspace, { recursive: true, force: true });
@@ -372,7 +383,7 @@ describe("AgentManager Slack status mirror", () => {
         call => call.method === "chat.postMessage"
       );
       expect(mirror?.args.text).toBe(
-        "▶︎ running\nstarted 0m ago · <https://cursor.com/agents/bc-child|view>"
+        "▶︎ running\nstarted just now · <https://cursor.com/agents/bc-child|view>"
       );
     } finally {
       rmSync(workspace, { recursive: true, force: true });
@@ -551,6 +562,75 @@ describe("AgentManager Slack status mirror", () => {
       ).mirrorTaskToSlack(task);
 
       expect(slackWebApiCalls()).toEqual([]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test("Noticed-idle attention does not flip the badge; stuck escalation does", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "orch-slack-mirror-stuck-"));
+    let postCount = 0;
+    resetSlackWebApiMock((method, args) => ({
+      ok: true,
+      channel: args.channel,
+      ts: method === "chat.update" ? args.ts : `333.${++postCount}`,
+    }));
+
+    try {
+      writeFileSync(
+        join(workspace, "plan.json"),
+        JSON.stringify(
+          {
+            goal: "mirror status",
+            rootSlug: "mirror-status",
+            baseBranch: "main",
+            repoUrl: "https://github.com/example-org/example-repo",
+            slackKickoffRef: { channel: "C123", ts: "111.222" },
+            tasks: [
+              {
+                name: "worker-one",
+                type: "worker",
+                scopedGoal: "Do the work.",
+              },
+            ],
+          },
+          null,
+          2
+        )
+      );
+      const mgr = await AgentManager.load(workspace);
+      const task = requireTask(mgr.getTask("worker-one"), "worker-one");
+
+      mgr.touch(task, {
+        agentId: "bc-child",
+        status: "running",
+        startedAt: new Date().toISOString(),
+      });
+      await waitFor(
+        () =>
+          slackWebApiCalls().some(call => call.method === "chat.postMessage"),
+        "initial running mirror"
+      );
+
+      mgr.logAttention(
+        "worker-one: SSE idle 300000ms, polled status=running; watchdog still waiting"
+      );
+      await new Promise(resolve => setTimeout(resolve, 25));
+      expect(
+        slackWebApiCalls().filter(c => c.method === "chat.update")
+      ).toHaveLength(0);
+
+      mgr.logAttention("worker-one: SSE idle 1800000ms; stuck");
+      await waitFor(
+        () => slackWebApiCalls().some(call => call.method === "chat.update"),
+        "stuck mirror"
+      );
+      const stuck = slackWebApiCalls().find(
+        call => call.method === "chat.update"
+      );
+      expect(stuck?.args.text).toBe(
+        "⚠ stuck\nno activity for 30m · <https://cursor.com/agents/bc-child|view>"
+      );
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }

--- a/orchestrate/skills/orchestrate/scripts/__tests__/models-catalog.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/models-catalog.test.ts
@@ -28,7 +28,7 @@ describe("MODEL_CATALOG", () => {
 
   // Verifiers do focused acceptance-criteria checks; xhigh is overkill there.
   test("defaultModelForType('verifier') returns opus high (not xhigh)", () => {
-    expect(defaultModelForType("verifier")).toBe("claude-opus-4-7");
+    expect(defaultModelForType("verifier")).toBe("claude-opus-4-8");
   });
 
   // Subplanners decompose, route, and synthesize; reserve xhigh for them.
@@ -36,7 +36,7 @@ describe("MODEL_CATALOG", () => {
   // there is no "planner" TaskType.)
   test("defaultModelForType('subplanner') returns opus xhigh", () => {
     expect(defaultModelForType("subplanner")).toBe(
-      "claude-opus-4-7-thinking-xhigh"
+      "claude-opus-4-8-thinking-xhigh"
     );
   });
 
@@ -74,11 +74,11 @@ describe("MODEL_CATALOG", () => {
 
   // Planners pass this slug straight through
   // `Task({ model })`. Without an entry, `resolveModelSelection` falls back to
-  // `{ id: "claude-opus-4-7-thinking-xhigh" }`, which the backend rejects as
+  // `{ id: "claude-opus-4-8-thinking-xhigh" }`, which the backend rejects as
   // `invalid_model`.
-  test("claude-opus-4-7-thinking-xhigh binds to opus with thinking + xhigh effort", () => {
-    const sel = resolveModelSelection("claude-opus-4-7-thinking-xhigh");
-    expect(sel.id).toBe("claude-opus-4-7");
+  test("claude-opus-4-8-thinking-xhigh binds to opus with thinking + xhigh effort", () => {
+    const sel = resolveModelSelection("claude-opus-4-8-thinking-xhigh");
+    expect(sel.id).toBe("claude-opus-4-8");
     const params = new Map((sel.params ?? []).map(p => [p.id, p.value]));
     expect(params.get("thinking")).toBe("true");
     expect(params.get("effort")).toBe("xhigh");

--- a/orchestrate/skills/orchestrate/scripts/bun.lock
+++ b/orchestrate/skills/orchestrate/scripts/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@cursor-skill/orchestrate",
       "dependencies": {
-        "@cursor/sdk": "^1.0.8",
+        "@cursor/sdk": "^1.0.12",
         "@slack/web-api": "^7.15.1",
         "commander": "^12.0.0",
         "zod": "^4.3.6",
@@ -43,17 +43,17 @@
 
     "@connectrpc/connect-node": ["@connectrpc/connect-node@1.7.0", "", { "dependencies": { "undici": "^5.28.4" }, "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A=="],
 
-    "@cursor/sdk": ["@cursor/sdk@1.0.8", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.8", "@cursor/sdk-darwin-x64": "1.0.8", "@cursor/sdk-linux-arm64": "1.0.8", "@cursor/sdk-linux-x64": "1.0.8", "@cursor/sdk-win32-x64": "1.0.8" } }, "sha512-8jpACxDwr2Cv73mZugWR99uN/nCfT/smJkPgUXCjUpJMZdIKeYXhCPUzrBgx+DZNf1QbMRcm8KthPRcQ8X8ShA=="],
+    "@cursor/sdk": ["@cursor/sdk@1.0.18", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.18", "@cursor/sdk-darwin-x64": "1.0.18", "@cursor/sdk-linux-arm64": "1.0.18", "@cursor/sdk-linux-x64": "1.0.18", "@cursor/sdk-win32-x64": "1.0.18" } }, "sha512-ha5EGHliMuTNuAqnPHzKFNnND4y6erddTqtxwIt9/p8ER+QsmMoRcP38PwA2sXfZnGvIBiozveBZqa4XwUddCw=="],
 
-    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lO6GONkBFrVqofez8W2ACfWiDv1Hkn0mTp5gwUzGX7s3cr1UQN3MhmatB6umCW/0Her7rfCDdvEyrszXGNvfDA=="],
+    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.18", "", { "os": "darwin", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-gXfNz+n3uf2hWCUcSdU/gBYT7TFlWwJjZAAjXFzBJ3jGu+l7ShQRa9QI2sEKvPNRtUMC/18EcQ26ks1o261Bnw=="],
 
-    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-OYwg45xB+JorM6pzBUtH3VXJ9NtUJvmXDlCPR8zforNMi/8sk2KFhgqt7nbCYG/V+uWd9YS5JTtjpzc2KEnwBA=="],
+    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.18", "", { "os": "darwin", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-nzcPqCvPPnYsuz21olPgandVgGUzDZkHN4cUls4ukm7mddp6XqujFJv8lh9qKmVefl0/3UL2R6GFANggjwifnA=="],
 
-    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-SN84cqr3yWoYWE5d++KDU5NirZdQSzf8u3GVcFzmF4I+mUqumtUqbGdunembEQdrsYibcGmyD1Un4ZzK4gVYXw=="],
+    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.18", "", { "os": "linux", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-MJyhVryN+0czP48SgMak/KA9xGneQ/gdsnDk1ZTJF+LemaFc+Tv7P1GT80h+3JBfu69kPyIX4epJVjroTMoFEA=="],
 
-    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.8", "", { "os": "linux", "cpu": "x64" }, "sha512-wdOZSVzsRbMiwnDsyaGodlFqeD0YnBKdMl+9axI/V74VAWp5U7JYThjFgehJRM+2yKVHlqHGxxGlHgHbcCOKGQ=="],
+    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.18", "", { "os": "linux", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-IaJqcKtXxtQEdPxivQjDWbvynw3UX31V8RdagcZ6RgHOo+B/i/P95D8svSNC4V9nbTHwVbNGfIDQ5S64gMS2hg=="],
 
-    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.8", "", { "os": "win32", "cpu": "x64" }, "sha512-yopN4NM2M52qIXVl95O+cadmmRSRskWc5IcVCjYT1KunlNlSyxxOcPOmrmhh60dASYWB34B/ysvRIO7NNqj/4g=="],
+    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.18", "", { "os": "win32", "cpu": "x64", "bin": { "rg": "bin/rg.exe" } }, "sha512-iqcGt1l/3xgnaT+PotY3237oyK3VnOZHtjUxSRP3Q7ahjaqsZVTnCwwljj+nal8ouvXidBHnxQLqGMSC2G6LTg=="],
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 

--- a/orchestrate/skills/orchestrate/scripts/cli/task.ts
+++ b/orchestrate/skills/orchestrate/scripts/cli/task.ts
@@ -21,8 +21,8 @@ import {
   loadOrBail,
   parsePositiveIntegerOrBail,
   parseRespawnSourceOrBail,
-  resolveKickoffSlackChannelOrBail,
   resolveKickoffRepoUrl,
+  resolveKickoffSlackChannelOrBail,
   resolveWorkspaceSlackChannelOrBail,
   type SpawnOptions,
   transitivelyDependsOn,
@@ -108,8 +108,11 @@ export function registerTaskCommands(program: Command): void {
     .argument("<goal>", "Root orchestration goal")
     .option("--repo <url>", "Repository URL to orchestrate")
     .option("--ref <ref>", "Starting git ref for the cloud workspace", "main")
-    .option("--model <id>", "Model id for the root planner", "claude-opus-4-7")
-    .option("--force", "Spawn a new root planner even when a recent matching run exists.")
+    .option("--model <id>", "Model id for the root planner", "claude-opus-4-8")
+    .option(
+      "--force",
+      "Spawn a new root planner even when a recent matching run exists."
+    )
     .option(
       "--slack-channel <id>",
       "Slack channel id for run visibility. Falls back to SLACK_CHANNEL_ID."

--- a/orchestrate/skills/orchestrate/scripts/core/agent-manager.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/agent-manager.ts
@@ -36,14 +36,21 @@ import {
   parseStateJson,
   TASK_NAME_RE,
 } from "../schemas.ts";
-import type { CommentDestinations } from "./comment-retry-queue.ts";
 import { plannedBranchForTask } from "./branches.ts";
+import type { CommentDestinations } from "./comment-retry-queue.ts";
 
 const SPAWN_MAX_ATTEMPTS = 3;
 const SPAWN_RETRY_BACKOFF_MS = 2_000;
 const WAIT_WATCHDOG_POLL_INTERVAL_MS = 60_000;
+// Internal watchdog "noticed idle" debug logs. Lower threshold = earlier
+// visibility into stalled SSE / tool-call streams without disturbing the
+// user-facing badge below.
 const WAIT_SSE_IDLE_ATTENTION_MS = 300_000;
 const WAIT_TOOL_CALL_IDLE_ATTENTION_MS = 300_000;
+// User-facing escalation. Watchdog logs a "; stuck" entry once idle crosses
+// this, and the Slack badge keys off that marker. Default 30m; overridable
+// for tool_call via ORCHESTRATE_TOOL_CALL_IDLE_MS.
+const STUCK_ESCALATION_MS = 1_800_000;
 // Caps rapid cycling if `run.wait()` errors sub-second while `Agent.getRun`
 // still reports running. Without it, state.attention and saveState frequency
 // would blow up. Negligible cost when retries take ~1-2 minutes.
@@ -934,7 +941,9 @@ export class AgentManager {
       }
       const prNumber = parseHandoffPrNumber(body);
       const sdkError =
-        rr.status === "finished" ? null : runResultErrorMessage(rr) ?? lastWaitError;
+        rr.status === "finished"
+          ? null
+          : (runResultErrorMessage(rr) ?? lastWaitError);
       const failureMode =
         parseHandoffFailureMode(body) ??
         (rr.status === "finished"
@@ -1383,7 +1392,7 @@ export class AgentManager {
     task: TaskState
   ): { kind: SlackDisplayKind; emoji: string; label: string } | null {
     if (task.status === "pending") return null;
-    if (task.status === "running" && this.latestIdleWarningMs(task) !== null) {
+    if (task.status === "running" && this.latestStuckIdleMs(task) !== null) {
       return { kind: "stuck", emoji: "⚠", label: "stuck" };
     }
     switch (task.status) {
@@ -1403,19 +1412,13 @@ export class AgentManager {
     }
   }
 
-  private slackSummaryForTask(
-    task: TaskState,
-    kind: SlackDisplayKind
-  ): string {
+  private slackSummaryForTask(task: TaskState, kind: SlackDisplayKind): string {
     const view = formatAgentFooter(task.agentId);
     switch (kind) {
       case "running":
-        return appendSlackView(
-          `started ${formatElapsedMinutes(task.startedAt)} ago`,
-          view
-        );
+        return appendSlackView(formatStartedSummary(task.startedAt), view);
       case "stuck": {
-        const idleMs = this.latestIdleWarningMs(task);
+        const idleMs = this.latestStuckIdleMs(task);
         return appendSlackView(
           `no activity for ${formatDurationMinutes(idleMs ?? 0)}`,
           view
@@ -1467,9 +1470,10 @@ export class AgentManager {
     }
   }
 
-  private latestIdleWarningMs(task: TaskState): number | null {
+  private latestStuckIdleMs(task: TaskState): number | null {
     for (const entry of [...this.state.attention].reverse()) {
       if (!entry.message.startsWith(`${task.name}:`)) continue;
+      if (!isStuckEscalationMessage(entry.message)) continue;
       const idleMs = parseIdleWarningMs(entry.message);
       if (idleMs !== null) return idleMs;
     }
@@ -1769,11 +1773,13 @@ function failureModeText(mode: TaskState["failureMode"]): string {
   }
 }
 
-function formatElapsedMinutes(startedAt: string | null): string {
-  if (!startedAt) return "0m";
+function formatStartedSummary(startedAt: string | null): string {
+  if (!startedAt) return "started just now";
   const started = Date.parse(startedAt);
-  if (!Number.isFinite(started)) return "0m";
-  return formatDurationMinutes(Date.now() - started);
+  if (!Number.isFinite(started)) return "started just now";
+  const epoch = Math.floor(started / 1000);
+  const fallback = new Date(started).toISOString().replace(/\.\d{3}Z$/, "Z");
+  return `started <!date^${epoch}^{ago}|${fallback}>`;
 }
 
 function formatDurationMinutes(ms: number): string {
@@ -1850,7 +1856,9 @@ async function waitRunWithWatchdog(args: {
 }): Promise<RunResult> {
   const ac = new AbortController();
   let idleEpisodeLogged = false;
+  let sseStuckEpisodeLogged = false;
   let toolCallIdleEpisodeLogged = false;
+  let toolCallStuckEpisodeLogged = false;
   const waitStartedAt = Date.now();
 
   const pollLoop = async (): Promise<RunResult> => {
@@ -1883,10 +1891,14 @@ async function waitRunWithWatchdog(args: {
           `${args.taskLabel}: SSE idle ${idleMs}ms, polled status=running; watchdog still waiting`
         );
       }
+      if (idleMs >= STUCK_ESCALATION_MS && !sseStuckEpisodeLogged) {
+        sseStuckEpisodeLogged = true;
+        args.logAttention(`${args.taskLabel}: SSE idle ${idleMs}ms; stuck`);
+      }
       const toolCallIdleMs =
         Date.now() - (args.lastToolCallAt.value ?? waitStartedAt);
       if (
-        toolCallIdleMs >= toolCallIdleThresholdMs() &&
+        toolCallIdleMs >= WAIT_TOOL_CALL_IDLE_ATTENTION_MS &&
         !toolCallIdleEpisodeLogged
       ) {
         toolCallIdleEpisodeLogged = true;
@@ -1897,6 +1909,15 @@ async function waitRunWithWatchdog(args: {
             lastToolCallAt: args.lastToolCallAt.value,
             waitStartedAt,
           })
+        );
+      }
+      if (
+        toolCallIdleMs >= toolCallStuckThresholdMs() &&
+        !toolCallStuckEpisodeLogged
+      ) {
+        toolCallStuckEpisodeLogged = true;
+        args.logAttention(
+          `${args.taskLabel}: tool_call idle ${toolCallIdleMs}ms; stuck`
         );
       }
     }
@@ -1992,13 +2013,15 @@ export function formatToolCallIdleWarning(args: {
   return `${args.taskLabel}: tool_call idle ${args.idleMs}ms; last=${lastCall}`;
 }
 
-function toolCallIdleThresholdMs(): number {
+function toolCallStuckThresholdMs(): number {
   const raw = process.env.ORCHESTRATE_TOOL_CALL_IDLE_MS;
-  if (!raw) return WAIT_TOOL_CALL_IDLE_ATTENTION_MS;
+  if (!raw) return STUCK_ESCALATION_MS;
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : WAIT_TOOL_CALL_IDLE_ATTENTION_MS;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : STUCK_ESCALATION_MS;
+}
+
+function isStuckEscalationMessage(message: string): boolean {
+  return /\b(?:SSE|tool_call) idle \d+ms; stuck$/.test(message);
 }
 
 function summarizeToolCall(event: unknown): ToolCallInspection {

--- a/orchestrate/skills/orchestrate/scripts/models.ts
+++ b/orchestrate/skills/orchestrate/scripts/models.ts
@@ -22,8 +22,8 @@ export interface ModelProfile {
 // Run `bun cli.ts models --check` after SDK or backend model-schema drift.
 export const MODEL_CATALOG: ModelProfile[] = [
   {
-    slug: "claude-opus-4-7",
-    selection: { id: "claude-opus-4-7" },
+    slug: "claude-opus-4-8",
+    selection: { id: "claude-opus-4-8" },
     summary: "Solid judgment Opus; right tier for verifier acceptance checks.",
     strengths: [
       "judgment",
@@ -39,7 +39,7 @@ export const MODEL_CATALOG: ModelProfile[] = [
   {
     slug: "opus-max",
     selection: {
-      id: "claude-opus-4-7",
+      id: "claude-opus-4-8",
       params: [
         { id: "thinking", value: "true" },
         { id: "context", value: "1m" },
@@ -50,7 +50,7 @@ export const MODEL_CATALOG: ModelProfile[] = [
       "Maximum-reasoning Opus; reserved for exceptionally difficult judgment tasks.",
     strengths: ["complex judgment", "deep reasoning", "ambiguity resolution"],
     speed: "slow",
-    use: "Reserved for exceptionally difficult tasks. May overthink simple problems — only reach for this when standard `claude-opus-4-7` has produced unsatisfying results.",
+    use: "Reserved for exceptionally difficult tasks. May overthink simple problems — only reach for this when standard `claude-opus-4-8` has produced unsatisfying results.",
   },
   {
     slug: "gpt-5.5-high-fast",
@@ -95,9 +95,9 @@ export const MODEL_CATALOG: ModelProfile[] = [
     use: "Workers whose task is non-trivial and where quality matters more than throughput. Reach for this over `gpt-5.5-high-fast` when subtle correctness matters more than turnaround.",
   },
   {
-    slug: "claude-opus-4-7-thinking-xhigh",
+    slug: "claude-opus-4-8-thinking-xhigh",
     selection: {
-      id: "claude-opus-4-7",
+      id: "claude-opus-4-8",
       params: [
         { id: "thinking", value: "true" },
         { id: "effort", value: "xhigh" },
@@ -107,7 +107,7 @@ export const MODEL_CATALOG: ModelProfile[] = [
       "Thinking Opus at xhigh effort; reserved for orchestration roles where deep judgment matters most.",
     strengths: ["judgment", "second opinions", "prose", "ambiguity resolution"],
     speed: "slow",
-    use: "Default for subplanners: they decompose, route, and synthesize, where deep judgment pays off. Also the the code discipline subagent default for prose, judgment, and second opinions. Resolved here so planners can pass the slug straight through `Task({ model })` without falling through to bare `{ id }` and being rejected as `invalid_model`.",
+    use: "Default for subplanners: they decompose, route, and synthesize, where deep judgment pays off. Also the code discipline subagent default for prose, judgment, and second opinions. Resolved here so planners can pass the slug straight through `Task({ model })` without falling through to bare `{ id }` and being rejected as `invalid_model`.",
     defaultFor: ["subplanner"],
   },
   {

--- a/orchestrate/skills/orchestrate/scripts/package.json
+++ b/orchestrate/skills/orchestrate/scripts/package.json
@@ -14,7 +14,7 @@
     "check": "biome check --write . && tsc --noEmit"
   },
   "dependencies": {
-    "@cursor/sdk": "^1.0.8",
+    "@cursor/sdk": "^1.0.12",
     "@slack/web-api": "^7.15.1",
     "commander": "^12.0.0",
     "zod": "^4.3.6",


### PR DESCRIPTION
Four maintenance fixes to the orchestrate scripts.

- Watchdog now separates a 5-minute "noticed idle" debug log from a 30-minute user-facing "stuck" escalation. The Slack badge flips to stuck only on the escalation marker instead of at the first idle warning, since 5m churned the channel on normal long tool calls. Tool-call escalation stays overridable via `ORCHESTRATE_TOOL_CALL_IDLE_MS`.
- The running badge renders start time with Slack's `<!date^epoch^{ago}|fallback>` directive so each viewer sees it in their own timezone, with a "started just now" fallback.
- Model catalog and the CLI root-planner default move from `claude-opus-4-7` to `claude-opus-4-8`.
- `@cursor/sdk` bumped `^1.0.8` to `^1.0.12` (lockfile regenerated).

Validation: `bun test` 208 pass / 0 fail, `tsc --noEmit` clean, Biome clean on the touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and default-model/SDK bumps in orchestrate scripts; no auth or data-path changes, with behavior covered by updated tests.
> 
> **Overview**
> Orchestrate script maintenance: **Slack stuck badges**, **per-viewer start times**, **Opus 4.8 defaults**, and **`@cursor/sdk` ^1.0.12**.
> 
> The run watchdog now logs **5m “noticed idle”** attention lines separately from **30m `; stuck` escalations**. The Slack task mirror only shows **⚠ stuck** when an escalation marker is present (not on the first idle warning), with tool-call stuck timing still overridable via `ORCHESTRATE_TOOL_CALL_IDLE_MS`. Running badges use Slack’s `<!date^…^{ago}|…>` for start time instead of a fixed “Xm ago” string.
> 
> Model catalog, kickoff CLI default, and dispatcher docs move from `claude-opus-4-7` to **`claude-opus-4-8`** (including thinking-xhigh bindings). Tests cover stuck vs noticed-idle mirroring and updated Slack date formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784c598ade96aea4ab8f5b7d8f8ca9f16220eb24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->