### PR TITLE
orchestrate: bump version to 1.1.0

### DIFF
--- a/orchestrate/.cursor-plugin/plugin.json
+++ b/orchestrate/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "orchestrate",
   "displayName": "Orchestrate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Fan a large task out across parallel Cursor cloud agents via the Cursor SDK: planners publish tasks, workers hand off back up, and a script reconciles the tree from disk and git.",
   "author": {
     "name": "Cursor",


### PR DESCRIPTION
Bumps the orchestrate plugin to 1.1.0 for the changes that landed in #118: the stuck-escalation badge, per-viewer start time, the Opus 4.8 move, and the @cursor/sdk 1.0.12 bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version field change with no code or behavior impact in this PR.
> 
> **Overview**
> **Release bump only:** updates `orchestrate/.cursor-plugin/plugin.json` from **1.0.0** to **1.1.0**.
> 
> This tags the plugin for functionality already merged elsewhere (e.g. #118): stuck-escalation badge, per-viewer start time, Opus 4.8 default, and `@cursor/sdk` 1.0.12. No runtime or logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f5510fc800b70750495d0f69b56f449fc44d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->