### PR TITLE
orchestrate: fix Biome lint and format errors in scripts

### DIFF
--- a/orchestrate/skills/orchestrate/scripts/__tests__/comment-cli.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/comment-cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { loadKickoffThreadTsOrBail } from "../cli/comments.ts";
+
 const TEST_SLACK_CHANNEL = "C123TEST";
 
 const CLI_PATH = new URL("../cli.ts", import.meta.url).pathname;

--- a/orchestrate/skills/orchestrate/scripts/__tests__/comment-retry-queue.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/comment-retry-queue.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { SlackAdapter, SlackMessageRef } from "../adapters/types.ts";
+
 const TEST_SLACK_CHANNEL = "C123TEST";
+
 import {
   commentRetryQueuePath,
   drainCommentRetryQueue,

--- a/orchestrate/skills/orchestrate/scripts/__tests__/failure-handoff.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/failure-handoff.test.ts
@@ -192,7 +192,12 @@ describe("hasStructuredHandoff", () => {
   // verifier-only match keeps the finished-no-handoff sidecar from
   // firing on every successful verifier run.
   test("Detects the verifier template's ## Verification heading", () => {
-    const body = ["## Verification", "live-ui-verified", "## Target", "`t`"].join("\n");
+    const body = [
+      "## Verification",
+      "live-ui-verified",
+      "## Target",
+      "`t`",
+    ].join("\n");
     expect(hasStructuredHandoff(body)).toBe(true);
   });
 

--- a/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/kickoff-dedupe.test.ts
@@ -4,9 +4,9 @@ import { spawnSync } from "node:child_process";
 const SCRIPTS_DIR = new URL("..", import.meta.url).pathname;
 
 import {
-  MAX_BOOT_MS,
   findActiveRootPlanner,
   inferKickoffRootSlug,
+  MAX_BOOT_MS,
 } from "../cli/task.ts";
 
 describe("kickoff dedupe", () => {
@@ -128,8 +128,12 @@ describe("kickoff dedupe", () => {
   });
 
   test("infers root slug from an explicit kickoff prefix", () => {
-    expect(inferKickoffRootSlug("refactor-ui: shrink Settings")).toBe("refactor-ui");
-    expect(inferKickoffRootSlug("`refactor-ui`: shrink Settings")).toBe("refactor-ui");
+    expect(inferKickoffRootSlug("refactor-ui: shrink Settings")).toBe(
+      "refactor-ui"
+    );
+    expect(inferKickoffRootSlug("`refactor-ui`: shrink Settings")).toBe(
+      "refactor-ui"
+    );
   });
 
   test("kickoff command adopts unless --force is passed", () => {

--- a/orchestrate/skills/orchestrate/scripts/__tests__/probe-models.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/probe-models.test.ts
@@ -59,7 +59,10 @@ describe("models --check", () => {
   });
 });
 
-function profile(slug: string, selection: ModelProfile["selection"]): ModelProfile {
+function profile(
+  slug: string,
+  selection: ModelProfile["selection"]
+): ModelProfile {
   return {
     slug,
     selection,

--- a/orchestrate/skills/orchestrate/scripts/__tests__/wait-handoff-failure.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/wait-handoff-failure.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import {
   existsSync,
   mkdtempSync,

--- a/orchestrate/skills/orchestrate/scripts/adapters/index.ts
+++ b/orchestrate/skills/orchestrate/scripts/adapters/index.ts
@@ -2,7 +2,9 @@ import { createSlackWebClient } from "./slack/client.ts";
 import { SlackApiAdapter } from "./slack/index.ts";
 import type { SlackAdapter } from "./types.ts";
 
-export function createSlackAdapter(channelId: string): SlackAdapter | undefined {
+export function createSlackAdapter(
+  channelId: string
+): SlackAdapter | undefined {
   const client = createSlackWebClient();
   if (!client) return undefined;
   return new SlackApiAdapter(client, channelId);

--- a/orchestrate/skills/orchestrate/scripts/cli/comments.ts
+++ b/orchestrate/skills/orchestrate/scripts/cli/comments.ts
@@ -147,9 +147,7 @@ async function uploadFileToThread(args: {
   }
   const slack = createSlackAdapter(args.channel);
   if (!slack) {
-    throw new Error(
-      "SLACK_BOT_TOKEN not set; cannot upload Slack file"
-    );
+    throw new Error("SLACK_BOT_TOKEN not set; cannot upload Slack file");
   }
   const content = readFileSync(args.filePath);
   const initial =
@@ -230,10 +228,10 @@ export function loadKickoffThreadTsOrBail(args: {
   return loadKickoffRefOrBail(args).threadTs;
 }
 
-function loadKickoffRefOrBail(args: {
-  workspace: string;
-  taskName: string;
-}): { channel: string; threadTs: string } {
+function loadKickoffRefOrBail(args: { workspace: string; taskName: string }): {
+  channel: string;
+  threadTs: string;
+} {
   const planPath = join(resolve(args.workspace), "plan.json");
   if (!existsSync(planPath)) {
     throw new Error(

--- a/orchestrate/skills/orchestrate/scripts/cli/util.ts
+++ b/orchestrate/skills/orchestrate/scripts/cli/util.ts
@@ -428,7 +428,9 @@ export function stripGitSuffix(url: string): string {
   return url.endsWith(".git") ? url.slice(0, -4) : url;
 }
 
-export function loadCommentDestinations(channelId: string): CommentDestinations {
+export function loadCommentDestinations(
+  channelId: string
+): CommentDestinations {
   return { slack: createSlackAdapter(channelId) };
 }
 

--- a/orchestrate/skills/orchestrate/scripts/core/prompts.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/prompts.ts
@@ -248,7 +248,9 @@ function renderMergeDiscipline(t: PlanTask, plan: Plan): string {
   const target = mergeWorkerTargetBranch(plan, t);
   const sources = mergeWorkerSourceBranches(plan, t);
   const sourceList =
-    sources.length > 0 ? sources.map(branch => `  - ${branch}`).join("\n") : "  - (none)";
+    sources.length > 0
+      ? sources.map(branch => `  - ${branch}`).join("\n")
+      : "  - (none)";
   return `
 - This is a merge worker for slice \`${slice}\`.
 - Merge dependency branches into \`${target}\` one at a time, in \`dependsOn\` order.

--- a/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
@@ -29,7 +29,10 @@ export function redactBody(text: string): { text: string; reasons: string[] } {
   return { text: redacted, reasons: [...reasons] };
 }
 
-function redactSensitiveAssignments(text: string, reasons: Set<string>): string {
+function redactSensitiveAssignments(
+  text: string,
+  reasons: Set<string>
+): string {
   return text.replace(SENSITIVE_ASSIGNMENT_RE, match => {
     const [key] = match.split(/\s*[:=]\s*/, 1);
     if (SENSITIVE_KEY_RE.test(key ?? "")) {


### PR DESCRIPTION
Runs Biome safe auto-fixes (formatting and import ordering) on the orchestrate plugin scripts to clear the pre-existing lint/format errors so the lane is green. No behavior change.

`bun test` 209 pass / 0 fail. `bun run typecheck` clean. Biome check clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic edits only; no logic, API, or security surface changes.
> 
> **Overview**
> Applies **Biome** safe auto-fixes across the orchestrate plugin `scripts` tree so lint/format checks pass—no intended runtime or test behavior change.
> 
> Changes are **style-only**: multi-line function signatures and ternaries, collapsed single-line `throw` strings, blank lines between import groups, and reordered named imports (e.g. `MAX_BOOT_MS` in `kickoff-dedupe.test.ts`). Touched areas include comment CLI tests, comment retry queue tests, failure-handoff tests, kickoff dedupe, probe-models, wait-handoff-failure, plus small formatting in `adapters/index.ts`, `cli/comments.ts`, `cli/util.ts`, `core/prompts.ts`, and `core/redact-body.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7a469afdfcda6ee604642edf49675d91a73a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->