### PR TITLE
pstack: self-unblock empirical forks with a sketch instead of asking

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -13,7 +13,7 @@ disable-model-invocation: true
 Remaining triggers:
 
 - Nontrivial change, architecture decision, or "are we sure?" → the **how** skill.
-- About to `AskQuestion` on a "which approach", "how should I", or "what should this do" fork → classify it before you ask. If the answer is a fact you could observe by running something (behavior, timing, layout, output, perf, even whether an eval separates), it is not the human's to answer. Sketch it via the Prototype playbook (`playbooks/prototype.md`) and let the result decide. Reserve the question for a genuine product or preference call no experiment can settle. The ask is the slow path. A throwaway probe usually answers faster, and it hands the human a result to react to instead of a decision to make.
+- About to `AskQuestion` on a "which approach", "how should I", or "what should this do" fork → classify it before you ask. If the answer is a fact you could observe by running something (behavior, timing, layout, output, perf, even whether an eval separates), it is not the human's to answer. Sketch it via the Prototype playbook (`playbooks/prototype.md`) and let the result decide. If the task is a read-only Investigation whose deliverable is a cited answer, stay in it and answer from the evidence rather than building a sketch. Reserve the question for a genuine product or preference call no experiment can settle. The ask is the slow path. A throwaway probe usually answers faster, and it hands the human a result to react to instead of a decision to make.
 - Any code → name the data shape first.
 - Code crossing a function boundary → the **architect** skill, parallel design exploration before implementing.
 - Contested design → the **interrogate** skill (four-model adversarial) before shipping.

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -13,6 +13,7 @@ disable-model-invocation: true
 Remaining triggers:
 
 - Nontrivial change, architecture decision, or "are we sure?" → the **how** skill.
+- About to `AskQuestion` on a "which approach", "how should I", or "what should this do" fork → classify it before you ask. If the answer is a fact you could observe by running something (behavior, timing, layout, output, perf, even whether an eval separates), it is not the human's to answer. Sketch it via the Prototype playbook (`playbooks/prototype.md`) and let the result decide. Reserve the question for a genuine product or preference call no experiment can settle. The ask is the slow path. A throwaway probe usually answers faster, and it hands the human a result to react to instead of a decision to make.
 - Any code → name the data shape first.
 - Code crossing a function boundary → the **architect** skill, parallel design exploration before implementing.
 - Contested design → the **interrogate** skill (four-model adversarial) before shipping.
@@ -111,7 +112,7 @@ A large or cross-cutting effort (a migration across many call sites, an ambitiou
 - **Trace forensics.** Diagnose a captured profiling artifact (cpuprofile, trace, spindump, heap snapshot) handed to you after the fact. The deliverable is a diagnosis, not a fix. `playbooks/trace-forensics.md`.
 - **Feature.** New or changed behavior, built from a named data shape. `playbooks/feature.md`.
 - **Refactoring.** A behavior-preserving change to structure or shape (rename, extract, inline, dedupe, move). `playbooks/refactoring.md`.
-- **Prototype.** A throwaway sketch to make a design decision cheaply before building it for real ("prototype", "mock it up", "try this layout"). `playbooks/prototype.md`.
+- **Prototype.** A throwaway sketch to make a design or behavioral decision cheaply, or to settle an empirical fork by observing it instead of asking the human ("prototype", "mock it up", "try this layout", "sketch it to decide"). `playbooks/prototype.md`.
 - **Visual parity.** Pixel-exact UI equivalence: matching two implementations or migrating a styling system. `playbooks/visual-parity.md`.
 - **Authoring or modifying a skill.** Writing or editing a SKILL.md. `playbooks/authoring-a-skill.md`.
 - **Eval.** Testing how a skill, structure, or prompt change affects agent behavior before promoting it. `playbooks/eval.md`.

--- a/pstack/skills/poteto-mode/playbooks/prototype.md
+++ b/pstack/skills/poteto-mode/playbooks/prototype.md
@@ -6,9 +6,9 @@ The one playbook where the Laziness Protocol's "smallest change" and the verific
 
 1. Scope the decision the prototype exists to make: which layout, which interaction, which density, or for an empirical fork which behavior, timing, or approach. No decision means no prototype; route to Feature.
 2. Gather references when the design space is open. Search for prior art, summarize a moodboard of themes, palettes, and layouts, let the user pick directions before building. Skip when the direction is set.
-3. Build throwaway in an isolated scratch dir, separate from production source. Vanilla HTML/CSS/JS or the lightest stack that renders the idea, CDN deps, a dev server with hot reload. No production framework, no tests, no abstractions.
+3. Build throwaway in an isolated scratch dir, separate from production source. For a visual decision, vanilla HTML/CSS/JS or the lightest stack that renders the idea, CDN deps, a dev server with hot reload. For a behavioral or timing decision, the smallest script that exercises the question. No production framework, no tests, no abstractions.
 4. When comparing alternatives, build them behind one switcher (buttons or a keypress), each variant labeled so the user can name it. This is the **exhaust-the-design-space** principle skill made cheap.
 5. Verify on the matching surface. For a visual decision, screenshot each variant via the control skill and drive the interaction; the eye is the test. For a behavioral or timing decision, observe the thing you are deciding by logging the timing, printing the output, or watching the render. The observation is the test here, not an assertion.
 6. Present alternatives, tradeoffs, and a recommendation. The output is the decision plus the throwaway artifact, not shippable code. Hand the chosen direction to **Feature** (or `architect` for the shape) for the real build.
 
-**Reply:** the variants explored, screenshots, tradeoffs, your recommendation, and the scratch path. Say plainly that the prototype is throwaway.
+**Reply:** the variants explored, the evidence (screenshots for a visual decision, the observed output or timing for a behavioral one), tradeoffs, your recommendation, and the scratch path. Say plainly that the prototype is throwaway.

--- a/pstack/skills/poteto-mode/playbooks/prototype.md
+++ b/pstack/skills/poteto-mode/playbooks/prototype.md
@@ -1,14 +1,14 @@
 ### Prototype
 
-**You own the design decision, not the code. The prototype is a throwaway instrument; the real build follows Feature.** For "prototype", "mock it up", "sketch this", "try this layout", or exploring a UI, interaction, or layout before committing.
+**You own the design decision, not the code. The prototype is a throwaway instrument; the real build follows Feature.** For "prototype", "mock it up", "sketch this", "try this layout", or exploring a UI, interaction, or layout before committing. Also for settling an empirical fork (which behavior, which timing, which approach) by observing it run, when you would otherwise ask the human a question a quick sketch could answer for you.
 
 The one playbook where the Laziness Protocol's "smallest change" and the verification bar invert. Speed over polish, code quality does not matter, no planning. The rigor is in picking the right design cheaply. Be bold: propose variations the user didn't ask for, throw an approach away and try another.
 
-1. Scope the decision the prototype exists to make: which layout, which interaction, which density. No decision means no prototype; route to Feature.
+1. Scope the decision the prototype exists to make: which layout, which interaction, which density, or for an empirical fork which behavior, timing, or approach. No decision means no prototype; route to Feature.
 2. Gather references when the design space is open. Search for prior art, summarize a moodboard of themes, palettes, and layouts, let the user pick directions before building. Skip when the direction is set.
 3. Build throwaway in an isolated scratch dir, separate from production source. Vanilla HTML/CSS/JS or the lightest stack that renders the idea, CDN deps, a dev server with hot reload. No production framework, no tests, no abstractions.
 4. When comparing alternatives, build them behind one switcher (buttons or a keypress), each variant labeled so the user can name it. This is the **exhaust-the-design-space** principle skill made cheap.
-5. Verify visually on the matching surface via the control skill: screenshot each variant, drive the interaction. The eye is the test here, not an assertion.
+5. Verify on the matching surface. For a visual decision, screenshot each variant via the control skill and drive the interaction; the eye is the test. For a behavioral or timing decision, observe the thing you are deciding by logging the timing, printing the output, or watching the render. The observation is the test here, not an assertion.
 6. Present alternatives, tradeoffs, and a recommendation. The output is the decision plus the throwaway artifact, not shippable code. Hand the chosen direction to **Feature** (or `architect` for the shape) for the real build.
 
 **Reply:** the variants explored, screenshots, tradeoffs, your recommendation, and the scratch path. Say plainly that the prototype is throwaway.


### PR DESCRIPTION
## Summary

- Adds a poteto-mode trigger that catches the `AskQuestion` reflex. Before asking the human a "which approach / how should I / what should this do" question, classify the fork. If the answer is empirical, observable by running something (behavior, timing, layout, output, perf), sketch it via the Prototype playbook and let the result decide. Reserve the ask for a genuine product or preference call no experiment can settle.
- Broadens the Prototype playbook from UI-only to cover empirical and behavioral forks, so the trigger has somewhere to route. Step 5 now names behavioral observation (log the timing, print the output, watch the render) as the test alongside the visual case.

## Why

This wires together two pieces that already exist, **Never Block on the Human** and **Prototype**, at the moment they fail to fire. An agent hits an empirically decidable fork (a timing, behavior, layout, or perf question) and asks the human instead of running a cheap experiment. A throwaway probe usually answers faster, and it hands the human a result to react to instead of a decision to make.

## Delivery

Two commits in dependency order. The Prototype playbook gains the empirical-fork capability, then poteto-mode adds the trigger that routes to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill playbooks; no runtime code or security-sensitive behavior.
> 
> **Overview**
> Adds a **poteto-mode** non-negotiable that runs before `AskQuestion` on “which approach / how should I / what should this do” forks. The agent must classify the fork first. If the answer is observable by running something (behavior, timing, layout, output, perf, eval separability), it routes to the **Prototype** playbook instead of asking. Investigation stays read-only with cited evidence. Questions are reserved for product or preference calls no experiment can settle.
> 
> The **Prototype** playbook and its index blurb are expanded beyond UI mocks to **empirical and behavioral** forks: scoping includes behavior/timing/approach, build step allows a minimal script (not only HTML/CSS), verification covers logging/printing/watching output, and replies call for observed evidence as well as screenshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46c16d6c3f0422ab68d33a249bc4b7ac6427832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


