### PR TITLE
pstack: add 'sequence work into verifiable units' principle

### DIFF
--- a/pstack/skills/figure-it-out/SKILL.md
+++ b/pstack/skills/figure-it-out/SKILL.md
@@ -38,6 +38,7 @@ Then put the design into motion. Add its steps to the todolist as concrete items
 ## Phase C: Run the loop
 
 Each unit is an experiment: state the hypothesis, make the smallest change, measure against the predicate on the real artifact, keep it if it advanced, revert it if it didn't.
+Apply the **sequence-verifiable-units** principle skill, verifying each unit before starting the next instead of batching checks at the end.
 
 - Verify by inspecting the artifact, never a self-report. When something passes too easily, suspect the observation method before the system. A blank screenshot passes a lazy gate.
 - Pair delegated work with a judge and audit the delegates' artifacts yourself before trusting them. If a worker games the gate, reset and harden the contract. If the gate itself is wrong, fix the gate in its own change rather than routing around it.

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -53,6 +53,7 @@ Read the leaf skill in full for any principle you apply. Each entry names when i
 
 - **Prove It Works** (**principle-prove-it-works**). After a task, before declaring done. Verify against the real artifact, not a proxy or "it compiles".
 - **Fix Root Causes** (**principle-fix-root-causes**). Debugging. Trace each symptom to its root cause, reproduce first, ask why until you reach it.
+- **Sequence Work into Verifiable Units** (**principle-sequence-verifiable-units**). Multi-step work (sweeps, migrations, runs of similar edits) and how you stack commits and PRs. Break work into small units that each end in a check, verify each before the next, and order delivery so the sequence proves itself.
 
 **Delegation**
 

--- a/pstack/skills/poteto-mode/playbooks/autonomous-run.md
+++ b/pstack/skills/poteto-mode/playbooks/autonomous-run.md
@@ -5,6 +5,7 @@
 1. State the exit condition as a checkable predicate before the first iteration (tests green, repro fixed, all N PRs merged, pixel-diff zero).
 2. Pick the wake mechanism using Cursor's `/loop` command (a built-in, not a pstack skill). An event to watch (CI, a merge, a ref advancing) gets a watcher subagent that wakes you on the event, with a long time-based heartbeat as fallback. No event gets a fixed-interval heartbeat sized to when the result is worth re-checking.
 3. Each iteration makes the smallest change the evidence justifies, verifies it against the predicate, commits if it advanced, discards changes that didn't help. Belt-and-suspenders that "might help" gets reverted, not left to ride.
+   Sequence the work via the **sequence-verifiable-units** principle skill, verifying each unit before the next instead of batching checks at the end.
 4. Checkpoint every iteration via the **show-me-your-work** skill, a row for what changed and whether the predicate moved.
 5. Stop when the predicate is met, or when two consecutive iterations make no progress. You are stuck then; surface it, don't spin. Never relax the predicate to declare victory.
 

--- a/pstack/skills/poteto-mode/playbooks/bug-fix.md
+++ b/pstack/skills/poteto-mode/playbooks/bug-fix.md
@@ -9,6 +9,7 @@ Be scientific. Every shipped line traces to runtime evidence. Belt-and-suspender
 3. Plan the fix. If it crosses a function boundary, `architect` first. Delegate implementation to a subagent using your configured bug-fix model (default `gpt-5.5-high-fast`) with a specific scope; review the diff.
 4. Verify on the same surface; the original repro now passes. "Inconclusive" or wrong-surface is not a pass; flag it. Unit tests show branch behavior, not bug absence.
 5. Stage the commits so the failing repro lands before the fix in git history; the diff tells the story. See the **tdd** skill for the failing-test-first cadence when the bug has a cheap local test path; skip it when the test would be expensive, integration-heavy, or unclear.
+   This is the canonical **sequence-verifiable-units** principle skill, the failing test first and the fix on top.
 6. Run **Opening a PR**.
 
 Investigation fans out `how` + `why` as parallel subagents.

--- a/pstack/skills/poteto-mode/playbooks/feature.md
+++ b/pstack/skills/poteto-mode/playbooks/feature.md
@@ -12,6 +12,7 @@
 4. Delegate code-writing to a subagent using your configured feature model (default `composer-2.5-fast`) with a specific scope (file paths, named data shape, success criteria); review its diff yourself. When the implementation admits multiple valid shapes (error handling, abstraction layer, test structure), delegate via the **arena** skill instead so the runners surface the alternatives and the cross-judge guards the pick. Mandatory: no skip-with-reason escape, and Laziness Protocol does not override it (the gain is review separation, not lines saved). You can spawn a subagent even though you are one; "the app is small" and "a subagent cannot spawn one" are both wrong. A subagent forbidden to spawn satisfies this by owning the diff directly with the same review separation; no "standing by" reply that waits on a nested agent. Comments per **Comments**. Surgical edits, re-ground against the source for upstream-derived files. Port shared-primitive improvements to all consumers and verify each. Commit liberally.
 5. Verify on the matching surface. "Inconclusive" or wrong-surface is not a pass; flag it.
 6. Rebase into small, ordered commits; stack follow-ups.
+   Use the **sequence-verifiable-units** principle skill, building, verifying, and committing each small unit before the next.
 7. If the design is contested, `interrogate` before shipping.
 8. Run **Opening a PR**.
 

--- a/pstack/skills/poteto-mode/playbooks/perf-issue.md
+++ b/pstack/skills/poteto-mode/playbooks/perf-issue.md
@@ -5,6 +5,7 @@
 1. Capture a baseline trace via the matching control skill.
 2. `how` to ground hypotheses; don't claim a perf ceiling without running it first.
 3. Plan the fix from the trace. If it crosses a function boundary, `architect` first. Delegate implementation to a subagent using your configured perf-issue model (default `gpt-5.5-high-fast`); review the diff. Capture a post-fix trace.
+   Apply the **sequence-verifiable-units** principle skill, verifying each attempt before trying the next.
 4. Parse and compare the artifacts (JSON to sqlite, diff). "Inconclusive" or wrong-surface is not a pass; flag it.
 5. Cite the measurement in the PR.
 6. Run **Opening a PR**.

--- a/pstack/skills/poteto-mode/playbooks/refactoring.md
+++ b/pstack/skills/poteto-mode/playbooks/refactoring.md
@@ -11,5 +11,6 @@ If the cleanup reveals a missing feature or a real bug, split it out and ship th
 5. Prove behavior is unchanged on the real artifact, not "it compiles" (**principle-prove-it-works**). For larger reshapes, run an equivalence check: a script that diffs old-vs-new outputs, a recorded baseline replayed against the new code, or a smoke run on the matching surface via the relevant control skill. Own the verification yourself; do not trust a delegate's "looks good" summary.
 6. Confirm the change earns its place. The success measure is reduced reader load (**principle-minimize-reader-load**): fewer layers between question and answer, less hidden state, fewer indirections without a second consumer. If the diff does not lower reader load somewhere, revert it.
 7. Rebase into small ordered commits that tell the story. A subtraction commit, then the reshape, then any follow-on cleanup, so a single revert undoes one slice. Run **Opening a PR**.
+   Shape the commits with the **sequence-verifiable-units** principle skill, so each behavior-preserving slice stays green before the next.
 
 **Reply:** the structure that changed, the pin you held it against, the equivalence proof, the reader-load delta, what shipped and what got reverted. No new behavior.

--- a/pstack/skills/principle-sequence-verifiable-units/SKILL.md
+++ b/pstack/skills/principle-sequence-verifiable-units/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: principle-sequence-verifiable-units
+description: "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work into small units that each end in a verifiable state, check each before the next, and order delivery so the sequence proves itself to a reviewer."
+disable-model-invocation: true
+---
+
+# Sequence work into verifiable units
+
+Order work as a sequence of small units, each ending in a state you can check, and don't advance until the current one is green. The same discipline runs at two altitudes, how you execute and how you deliver.
+
+**Why:** A break caught at the unit that caused it is cheap to localize. A break caught after a batch is buried, and you have already built further on a broken base. Sequencing those same units into a delivery a reviewer can replay turns "trust me" into "watch it go red, then green."
+
+**Execution.** In a sweep, migration, or any run of similar edits, verify each change before starting the next. Never batch the edits and verify once at the end. Each unit is a before/after bracket: known-good state, one change, run the check, then proceed. Rebase onto clean trunk first so every check measures against the real baseline. When a lever does the edits, the per-unit check is nearly free; run it anyway.
+
+**Delivery.** Stack commits and PRs in the order that proves the work. The canonical shape is the failing test first, then the fix on top. The first unit shows the bug is real (red), the next shows it resolved (green), so a reviewer sees both the problem and the proof. Other story orders are a subtraction before the reshape, a baseline capture before the treatment, the scaffold before the feature. Each commit lands on its own and the sequence reads as an argument.
+
+**Pattern:**
+- Pick the smallest unit that ends in a check: an edit plus its test, or a commit that stands alone.
+- Verify before advancing. Red to green per unit, never deferred to a final batch.
+- Order the units so the sequence builds confidence on its own, for you while executing and for a reviewer reading the stack.
+
+The sequencing complement to the **prove-it-works** principle skill, which keeps each check real, and the **build-the-lever** principle skill, which makes the per-unit check cheap.


### PR DESCRIPTION
## Summary

- New principle, **sequence work into verifiable units**. Break multi-step work into small units that each end in a check, verify each before the next, and order delivery so the sequence proves itself to a reviewer.
- Threads it into the playbooks where it applies: the iterate-and-verify steps of perf-issue and autonomous-run, the commit-staging steps of bug-fix, feature, and refactoring, and the figure-it-out loop.

## Why

Two altitudes, one discipline. While executing, a break caught at the unit that caused it is cheap to localize, while a break caught after a batch is buried on top of more work. While delivering, stacking the units in story order, the failing test first then the fix, turns "trust me" into "watch it go red, then green" for a reviewer.

## Delivery

Two commits. The principle leaf and its index entry first, then the threading into the playbooks that reference it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skills and playbooks; no application runtime or security paths.
> 
> **Overview**
> Adds a new **sequence work into verifiable units** principle (`principle-sequence-verifiable-units`) and registers it under **Verification** in **poteto-mode**.
> 
> The skill splits discipline into **execution** (verify each small change before the next, no batch-then-check) and **delivery** (stack commits/PRs so reviewers see red-then-green and similar story order). It positions itself alongside **prove-it-works** and **build-the-lever**.
> 
> Existing playbooks and **figure-it-out** Phase C now explicitly cite this principle where iteration, commit ordering, or per-attempt verification already applied: autonomous-run, perf-issue, bug-fix (failing repro before fix), feature and refactoring (small ordered commits), and the figure-it-out hypothesis loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621f4595756eb788e112f94a117f6b5305fb865c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->