### PR TITLE
pstack: bump version to 0.9.0

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
## Summary

- Bumps the plugin from 0.8.0 to 0.9.0 for the recent poteto-mode work now on main: the sequence-verifiable-units principle (#123), the self-unblock empirical-fork trigger (#122), and the prototype and refactoring playbook fixes (#124).

## Delivery

One commit, the version field only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version field change with no runtime or behavioral code modifications.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin release from **0.8.0** to **0.9.0** in `plugin.json` only—no skill, agent, or workflow file changes in this PR.
> 
> The version aligns the published plugin with recent **poteto-mode** updates already on main (sequence-verifiable units, self-unblock empirical-fork trigger, prototype/refactoring playbook fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01cb63f812c97830ecafee1c21dc41a6c0e6b163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->