### PR TITLE
pstack: sync README with shipped principles and playbooks

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -32,7 +32,7 @@ use `/poteto-mode` at the start of a task. it reads your request, picks from a s
 
 ### just use `/poteto-mode`
 
-this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with fourteen playbooks:
+this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with fifteen playbooks:
 
 | playbook | for |
 |---|---|
@@ -43,12 +43,13 @@ this skill is the main shortcut. i use it whenever i need the agent to do rigoro
 | trace forensics | diagnose a captured profiling artifact (cpuprofile, trace, spindump, heap snapshot). |
 | feature | new or changed behavior, built from a named data shape. |
 | refactoring | a behavior-preserving change to structure or shape. |
-| prototype | a throwaway sketch to make a design decision cheaply. |
+| prototype | a throwaway sketch to make a design or behavioral decision cheaply, or to settle an empirical fork by observing it. |
 | visual parity | pixel-exact ui equivalence between two implementations. |
 | authoring a skill | writing or editing a SKILL.md. |
 | eval | test how a skill or prompt change affects agent behavior, blinded. |
 | autonomous run | drive a long task to completion without stopping. |
 | session pickup | resume or take over a prior agent's in-flight work. |
+| pause safely | suspend in-flight work cleanly so it can be resumed later. |
 | multi-phase plan | work that spans phases or stacked PRs. |
 
 when invoked it:
@@ -127,11 +128,11 @@ pstack also ships a subagent that runs my style end to end. spawn it from a pare
 
 ## principles
 
-nineteen short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
+twenty short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
 
 - core: laziness-protocol, foundational-thinking, redesign-from-first-principles, subtract-before-you-add, minimize-reader-load, outcome-oriented-execution, experience-first, exhaust-the-design-space, build-the-lever.
 - architecture: boundary-discipline, type-system-discipline, make-operations-idempotent, migrate-callers-then-delete-legacy-apis, separate-before-serializing-shared-state.
-- verification: prove-it-works, fix-root-causes.
+- verification: prove-it-works, fix-root-causes, sequence-verifiable-units.
 - delegation: guard-the-context-window, never-block-on-the-human.
 - meta: encode-lessons-in-structure.
 


### PR DESCRIPTION
## Summary

- Principles: nineteen to twenty, and add `sequence-verifiable-units` to the verification group. It shipped as a leaf skill and in the poteto-mode index but the README count and list were not updated.
- Playbooks: fourteen to fifteen, and add the `pause-safely` row. The playbook shipped earlier but the README table never picked it up.
- Broaden the `prototype` one-liner so it matches the playbook's current scope (it also settles an empirical fork by observation), consistent with the poteto-mode catalog entry.

Doc only. Verified the principle count against `ls skills/principle-*` (twenty).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation updates only; no runtime or skill behavior changes.
> 
> **Overview**
> **Doc-only sync** so `pstack/README.md` matches shipped `poteto-mode` playbooks and principle skills.
> 
> The playbook section now says **fifteen** playbooks (was fourteen) and adds a **`pause safely`** row for suspending work with a clean resume checkpoint. The **`prototype`** blurb is expanded to cover behavioral decisions and settling empirical forks by observation, aligned with `SKILL.md`.
> 
> The principles section now counts **twenty** skills (was nineteen) and lists **`sequence-verifiable-units`** under verification alongside what was already in the index and leaf skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cae5b43844bda51c878c14251f415d33e07d5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->