### PR TITLE
pstack: add the teach skill

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -72,6 +72,7 @@ the rest are useful when you want to specifically invoke them:
 | `/poteto-mode` | default entry point for any non-trivial task. |
 | `/how` | you want a walkthrough of how a subsystem works. |
 | `/why` | you want to know why something was built this way. discovers available MCPs at run time and queries each evidence category in parallel (source control, issue tracker, long-form docs, real-time chat, infra observability, error tracking, analytics warehouse). |
+| `/teach` | you want a body of work explained plainly. composes `how` and `why` into one paced, layered explanation led by the single core idea, no quizzes. |
 | `/architect` | you're about to write code that crosses a function boundary and want the caller's usage, types, and module shape settled first. |
 | `/arena` | you want N parallel attempts at the same thing, then to grab the best parts of each. |
 | `/interrogate` | you have a diff and want four different models to try to break it, including a strict code-quality lens. |

--- a/pstack/skills/teach/SKILL.md
+++ b/pstack/skills/teach/SKILL.md
@@ -11,10 +11,10 @@ Teach is the synthesizer over `how` and `why`. It orients on what the work is an
 
 1. Scope the work and decide the few things they should walk away understanding.
 2. Run the engines, don't reconstruct them. Orient yourself on what it is and what it touches by reading the work directly, then invoke `how` for the mechanics and `why` for the rationale. Teach spawns them in parallel and synthesizes the results. Size the fan-out to the question: run both for a subsystem, one may be enough for a small change, and keep `why` narrow by default (git plus a source or two) since its full multi-source sweep is slow, widening it only when the rationale is the point.
-3. Lead with the one idea to hold onto. Name the single core idea first in plain words, then hang the rest off it: what it is and why it matters, how it works, the deeper whys and edge cases. Give the smallest complete answer first and stop. The layers expand on request, not all at once. Never a wall.
+3. Open with the single core idea as a plain sentence, with no framing label in front of it. No "the one idea to hold onto", no "the key insight", no "at its core", no "TL;DR". Just state the idea, then hang the rest off it: what it is and why it matters, how it works, the deeper whys and edge cases. Give the smallest complete answer first and stop. The layers expand on request, not all at once. Never a wall.
 4. Pace to them. Have them restate where it helps and fill from there. Offer to go deeper or move on and let them steer. No quizzes, no keeping the session open until they pass.
 5. Show, don't only tell. Open the diff, the code, or the debugger when it lands faster than prose. Reach for a mermaid diagram when a flow or a structure is clearer drawn than described, and generate an image when a spatial or visual idea is easier seen. Use a visual when it carries the explanation, not as decoration.
 
 Write every response through the **unslop** skill. The explanation is a prose surface someone reads to understand, so keep it plain and free of AI tells.
 
-**Reply:** the one core idea, then the plain account of what it is, how it works, and why, and the threads worth chasing with `how` or `why`.
+**Reply:** the core idea up front, then the plain account of what it is, how it works, and why, and the threads worth chasing with `how` or `why`.

--- a/pstack/skills/teach/SKILL.md
+++ b/pstack/skills/teach/SKILL.md
@@ -9,12 +9,12 @@ description: "Explain a body of work plainly to a person by composing the how an
 
 Teach is the synthesizer over `how` and `why`. It orients on what the work is and what it touches, then runs `how` for the mechanics and `why` for the rationale as real skill invocations that fan out their own subagents, and weaves their findings into one plain-language account, led by impact and deepened on request. It spawns the engines and composes their output; it does not redo their investigation by hand.
 
-1. Scope the work and keep a short running checklist of what they should walk away with.
+1. Scope the work and decide the few things they should walk away understanding.
 2. Run the engines, don't reconstruct them. Orient yourself on what it is and what it touches by reading the work directly, then invoke `how` for the mechanics and `why` for the rationale. Teach spawns them in parallel and synthesizes the results. Size the fan-out to the question: run both for a subsystem, one may be enough for a small change, and keep `why` narrow by default (git plus a source or two) since its full multi-source sweep is slow, widening it only when the rationale is the point.
 3. Lead with the one idea to hold onto. Name the single core idea first in plain words, then hang the rest off it: what it is and why it matters, how it works, the deeper whys and edge cases. Give the smallest complete answer first and stop. The layers expand on request, not all at once. Never a wall.
 4. Pace to them. Have them restate where it helps and fill from there. Offer to go deeper or move on and let them steer. No quizzes, no keeping the session open until they pass.
-5. Show, don't only tell. Open the diff, the code, or the debugger when it lands faster than prose.
+5. Show, don't only tell. Open the diff, the code, or the debugger when it lands faster than prose. Reach for a mermaid diagram when a flow or a structure is clearer drawn than described, and generate an image when a spatial or visual idea is easier seen. Use a visual when it carries the explanation, not as decoration.
 
 Write every response through the **unslop** skill. The explanation is a prose surface someone reads to understand, so keep it plain and free of AI tells.
 
-**Reply:** the one core idea, then the plain account of what it is, how it works, and why, the checklist of what is now understood, and the threads worth chasing with `how` or `why`.
+**Reply:** the one core idea, then the plain account of what it is, how it works, and why, and the threads worth chasing with `how` or `why`.

--- a/pstack/skills/teach/SKILL.md
+++ b/pstack/skills/teach/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: teach
+description: "Explain a body of work plainly to a person by composing the how and why skills. Use for 'teach me this', 'help me really understand X', 'explain this change or subsystem to me properly'. Synthesizes how (mechanics) and why (rationale) into one paced, layered explanation led by the single core idea."
+---
+
+# Teach
+
+**You weave what a thing is, how it works, and why it is that way into one plain explanation, paced to the human. The deliverable is their understanding, not a change.** For "teach me this", "help me really understand X", "explain this change or subsystem to me properly".
+
+Teach is the synthesizer over `how` and `why`. It orients on what the work is and what it touches, then runs `how` for the mechanics and `why` for the rationale as real skill invocations that fan out their own subagents, and weaves their findings into one plain-language account, led by impact and deepened on request. It spawns the engines and composes their output; it does not redo their investigation by hand.
+
+1. Scope the work and keep a short running checklist of what they should walk away with.
+2. Run the engines, don't reconstruct them. Orient yourself on what it is and what it touches by reading the work directly, then invoke `how` for the mechanics and `why` for the rationale. Teach spawns them in parallel and synthesizes the results. Size the fan-out to the question: run both for a subsystem, one may be enough for a small change, and keep `why` narrow by default (git plus a source or two) since its full multi-source sweep is slow, widening it only when the rationale is the point.
+3. Lead with the one idea to hold onto. Name the single core idea first in plain words, then hang the rest off it: what it is and why it matters, how it works, the deeper whys and edge cases. Give the smallest complete answer first and stop. The layers expand on request, not all at once. Never a wall.
+4. Pace to them. Have them restate where it helps and fill from there. Offer to go deeper or move on and let them steer. No quizzes, no keeping the session open until they pass.
+5. Show, don't only tell. Open the diff, the code, or the debugger when it lands faster than prose.
+
+Write every response through the **unslop** skill. The explanation is a prose surface someone reads to understand, so keep it plain and free of AI tells.
+
+**Reply:** the one core idea, then the plain account of what it is, how it works, and why, the checklist of what is now understood, and the threads worth chasing with `how` or `why`.


### PR DESCRIPTION
## Summary

- New skill `teach`. It composes `how` (mechanics) and `why` (rationale) into one plain, paced explanation of a body of work, led by a single core idea, with deeper layers named as threads and the prose run through `unslop`. It spawns the two engines as real skill invocations rather than re-deriving them, and keeps the `why` fan-out narrow by default since its full multi-source sweep is slow, widening only when the rationale is the point.
- Adds the `/teach` row to the skills table.

## Why

`how` and `why` answer mechanics and rationale separately. `teach` is the synthesizer that explains a change or subsystem plainly to a person, the thing you reach for with "teach me this" or "explain this PR properly".

## Validated

Test-driven across Opus, GPT-5.5, and Composer on real targets (changes, subsystems, functions, infra, packages). The structure held across all three models, and the real `how`/`why` orchestration produced evidence-grounded explanations. Judged on the real outputs, not a sandbox eval.

No version bump in this PR; a bump can follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill definition and README table row; no runtime or application code changes.
> 
> **Overview**
> Adds **`/teach`**, a new pstack skill that **synthesizes** existing **`how`** and **`why`** into one human-paced explanation of a change or subsystem—not a code change workflow.
> 
> The new `pstack/skills/teach/SKILL.md` defines orchestration: scope the topic, **invoke `how` and `why` as real skills** (parallel when both matter, with a **narrow default `why` fan-out** because full multi-source `why` is slow), then weave results into a plain answer **led by one core sentence** (no TL;DR-style labels), layered depth on request, optional visuals, and prose via **`unslop`**. The README skills table documents when to use `/teach` versus standalone `/how` or `/why`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9f10e8d5f939f85edfeeb043410600b4135cdda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->