### PR TITLE
Preserve Cursor summary block in make-pr-easy-to-review skill

### DIFF
--- a/cursor-team-kit/skills/make-pr-easy-to-review/SKILL.md
+++ b/cursor-team-kit/skills/make-pr-easy-to-review/SKILL.md
@@ -52,6 +52,20 @@ When code behavior should stay untouched, prefer PR description and review notes
 - Call out risky behavior changes, migration order, rollout plan, and test coverage.
 - Link issue trackers, dashboards, or design docs when they explain intent.
 
+### Preserve the Cursor-generated comment block
+
+When editing a PR description, fetch the existing body first:
+
+```bash
+gh pr view <PR> --json body -q .body
+```
+
+If the body contains a Cursor-generated block delimited by `<!-- CURSOR_SUMMARY -->` and `<!-- /CURSOR_SUMMARY -->`, **leave that block intact** — do not remove, rewrite, or relocate it. It may include risk level, change summary, and Bugbot notes that Cursor or Bugbot maintain.
+
+Also preserve any trailing Cursor agent footer (the `Open in Web` / `Open in Cursor` link div) if present.
+
+Add reviewer guidance **outside** the Cursor block — typically above it or in clearly separate sections below. When running `gh pr edit`, reconstruct the full body with the preserved block(s) copied verbatim from the original.
+
 ## Guardrails
 
 - Never hide meaningful behavior changes inside "cleanup".


### PR DESCRIPTION
## Summary

- Adds guidance to the `make-pr-easy-to-review` skill to preserve the `

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent skill guidance; no runtime or product behavior is affected.
> 
> **Overview**
> Extends the **`make-pr-easy-to-review`** skill so agents don’t wipe Cursor-maintained PR description content when they add reviewer notes.
> 
> Under **Reviewer Guidance**, a new subsection tells agents to **`gh pr view`** the existing body first, keep the `<!-- CURSOR_SUMMARY -->` … `<!-- /CURSOR_SUMMARY -->` block verbatim (including risk/Bugbot content), preserve the trailing **Open in Web / Open in Cursor** footer when present, and place new guidance outside that block when using **`gh pr edit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d5a3adb1695cdb9fe398a7f0f8780dabfb672d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

` block when editing PR descriptions.
- Also preserves the trailing Cursor agent footer (`Open in Web` / `Open in Cursor` links) if present.
- Instructs agents to fetch the existing PR body first and add reviewer guidance outside the Cursor-generated block.

## Motivation

When agents run `/make-pr-easy-to-review`, they often rewrite the PR description with reviewer guidance (TL;DR, file walkthrough, etc.). That can accidentally strip the Cursor-generated summary and Bugbot notes, which Cursor and Bugbot maintain separately from agent-authored review notes.

## Test plan

- [ ] Verify the skill text is clear and actionable for agents editing PR bodies via `gh pr edit`
- [ ] Confirm no other cursor-team-kit skills conflict with this guidance


Made with [Cursor](https://cursor.com)