### PR TITLE
Add Falconer plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,6 +9,11 @@
   },
   "plugins": [
     {
+      "name": "falconer",
+      "source": "falconer",
+      "description": "Read, search, and update Falconer documents through hosted HTTP MCP."
+    },
+    {
       "name": "teaching",
       "source": "teaching",
       "description": "Skill mapping, practice plans, and learning retrospectives."

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 
 | `name` | Plugin | Author | Category | `description` (from marketplace) |
 |:-------|:-------|:-------|:---------|:-------------------------------------|
+| `falconer` | [Falconer](falconer/) | Falconer AI | Productivity | Read, search, and update Falconer documents through hosted HTTP MCP. |
 | `continual-learning` | [Continual Learning](continual-learning/) | Cursor | Developer Tools | Incremental transcript-driven memory updates for AGENTS.md using high-signal bullet points only. |
 | `cursor-team-kit` | [Cursor Team Kit](cursor-team-kit/) | Cursor | Developer Tools | Internal team workflows used by Cursor developers for CI, code review, shipping, local automation, and verification. |
 | `thermos` | [Thermos](thermos/) | Cursor | Developer Tools | Thermo-nuclear branch review: deep security/correctness audits, harsh code-quality rubrics, parallel subagents, thermos orchestration, and optional merge-ready PR flows. |

--- a/falconer/.cursor-plugin/plugin.json
+++ b/falconer/.cursor-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "falconer",
+  "displayName": "Falconer",
+  "description": "Read, search, and update Falconer documents from Cursor through hosted HTTP MCP.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Falconer AI",
+    "email": "support@falconer.com"
+  },
+  "publisher": "Falconer AI",
+  "homepage": "https://falconer.com",
+  "repository": "https://github.com/FalconerAI/falconer-agent-integrations",
+  "license": "Apache-2.0",
+  "keywords": ["falconer", "mcp", "docs", "documents", "knowledge"],
+  "category": "Productivity",
+  "tags": ["mcp", "documentation", "knowledge-management"],
+  "skills": "skills/**/SKILL.md",
+  "mcpServers": "mcp.json"
+}

--- a/falconer/LICENSE
+++ b/falconer/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Falconer AI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/falconer/README.md
+++ b/falconer/README.md
@@ -1,0 +1,11 @@
+# Falconer
+
+Use Falconer documents from supported agent clients through hosted HTTP MCP.
+
+This plugin package is remote-only and connects to:
+
+```text
+https://falconer.com/api/mcp
+```
+
+Supported v1 clients are Cursor, Claude Code, and Codex.

--- a/falconer/mcp.json
+++ b/falconer/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "falconer": {
+      "url": "https://falconer.com/api/mcp"
+    }
+  }
+}

--- a/falconer/skills/falconer-knowledge/SKILL.md
+++ b/falconer/skills/falconer-knowledge/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: falconer-knowledge
+description: "Use when working with Falconer documents through MCP: reading, searching, drafting, editing, preserving Falconer Markdown syntax, using rich document blocks, uploading media, or changing document navigation, comments, permissions, or revisions."
+---
+
+# Falconer Knowledge
+
+Use Falconer MCP tools to read, search, create, and update Falconer documents. Falconer document content is Markdown with Falconer-specific extensions. Preserve existing syntax exactly unless the user explicitly asks to change it.
+
+## Core rules
+
+- Preserve inline references exactly: `![f>][reference-id]`.
+- Preserve legacy inline references exactly: `![f>][display text][reference-id]`.
+- Do not invent Falconer reference IDs.
+- Prefer targeted content tools over whole-document overwrite.
+- Use `upload_media` before inserting local image or video content.
+- Ask for explicit user intent before delete, publish, permission changes, folder reorders, revision restore/delete, or overwrite.
+- Inspect navigation placement before moving documents or folders.
+
+## Formatting
+
+For Falconer-specific Markdown and rich components, read `references/falconer-formatting.md` when drafting or editing document content.
+
+## Editing workflow
+
+1. Read the relevant document before editing.
+2. Preserve references, math, tables, task lists, diagrams, callouts, and rich blocks unless the requested change requires modifying them.
+3. Use targeted replace, insert, or delete tools when possible.
+4. Use overwrite only when the user clearly asks for a full rewrite or replacement.
+5. After editing, summarize the material change and call out any risky operation performed.

--- a/falconer/skills/falconer-knowledge/references/falconer-formatting.md
+++ b/falconer/skills/falconer-knowledge/references/falconer-formatting.md
@@ -1,0 +1,205 @@
+# Falconer formatting
+
+Falconer documents use Markdown plus Falconer-specific references and rich blocks.
+
+## References
+
+Preserve existing Falconer references exactly:
+
+```markdown
+![f>][reference-id]
+![f>][display text][reference-id]
+```
+
+Do not invent new reference IDs. If a reference is needed and no ID exists, write normal text and ask the user or use available Falconer tools to find the referenced content.
+
+## Headings
+
+Falconer supports four heading levels:
+
+```markdown
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+```
+
+## Text styles
+
+Use standard Markdown for bold, italic, strikethrough, links, and inline code:
+
+```markdown
+**bold**
+*italic*
+~~struck through~~
+`inline code`
+[link](https://falconer.com)
+```
+
+Highlights use `mark` tags with Falconer color tokens:
+
+```html
+<mark data-color="blue" style="background-color: hsl(var(--editor-color-blue)); color: inherit; padding-top: 2px; padding-bottom: 3px;">highlighted text</mark>
+```
+
+Supported highlight colors are red, orange, yellow, green, blue, and purple.
+
+## Lists and tasks
+
+Use GitHub-flavored Markdown for lists and task lists:
+
+```markdown
+- Parent item
+  - Child item
+
+1. First item
+2. Second item
+
+- [x] Finished task
+- [ ] Open task
+```
+
+## Callouts
+
+Falconer supports these callouts:
+
+```markdown
+> [!NOTE]
+>
+> Helpful context or a tip.
+
+> [!CAUTION]
+>
+> Something to be careful about.
+
+> [!DANGER]
+>
+> Something that can cause real harm.
+```
+
+## Code
+
+Use fenced code blocks with a language:
+
+```python
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+```
+
+## Tables
+
+Use GitHub-flavored Markdown tables:
+
+```markdown
+| Element | How to insert it | Sortable |
+| --- | --- | --- |
+| Heading | `## ` | No |
+| Table | `/table` | Yes |
+```
+
+## Math
+
+Falconer renders LaTeX with KaTeX:
+
+```markdown
+Inline math: $E = mc^2$
+
+Centered block:
+
+$$
+\int_0^\infty e^{-x}\,dx = 1
+$$
+```
+
+Some existing documents may use `$$inline math$$` or block math fenced with `$$...$$` or `$$$...$$$`. Preserve existing math delimiters unless changing them is necessary.
+
+## Diagrams
+
+Use Mermaid code blocks for diagrams:
+
+```mermaid
+flowchart LR
+    Write[Write] --> Connect[Connect tools]
+    Connect --> Automate[Docs stay current]
+```
+
+## Columns
+
+Use columns for side-by-side content:
+
+```markdown
+<Columns cols={2}>
+  <Column>
+**Write**
+
+Draft docs in a Markdown-native editor.
+  </Column>
+  <Column>
+**Connect**
+
+Pull in code, conversations, and meeting notes.
+  </Column>
+</Columns>
+```
+
+## Cards
+
+Cards are icon-topped tiles:
+
+```markdown
+<Card icon="rocket" cta="Start writing">
+
+Open a new doc and try the slash menu.
+
+</Card>
+```
+
+## Accordions
+
+Use accordions for optional detail:
+
+```markdown
+<AccordionGroup>
+
+<Accordion title="When should I use an accordion?">
+
+For optional detail that would clutter the main flow if shown by default.
+
+</Accordion>
+
+</AccordionGroup>
+```
+
+## Tabs
+
+Use tabs for alternatives:
+
+```markdown
+<Tabs>
+
+<Tab title="For writers">
+
+Use callouts, tables, and headings to make docs scannable.
+
+</Tab>
+
+<Tab title="For engineers">
+
+Use code blocks, math, and Mermaid diagrams.
+
+</Tab>
+
+</Tabs>
+```
+
+## Media
+
+For local images or videos, call `upload_media` first and insert the returned snippet. Do not guess asset URLs or write local filesystem paths into Falconer documents.
+
+## Divider
+
+Use a horizontal rule for dividers:
+
+```markdown
+---
+```


### PR DESCRIPTION
## Summary
- Adds the Falconer Cursor plugin with hosted HTTP MCP configuration
- Includes Falconer document authoring skill guidance and formatting reference
- Adds Falconer to the Cursor plugin marketplace index and README table

## Validation
- Cursor plugin schema validation passed for falconer/.cursor-plugin/plugin.json
- Cursor marketplace schema validation passed for .cursor-plugin/marketplace.json
- Skill validation passed for falconer/skills/falconer-knowledge
- Confirmed no local stdio command transport references in the Falconer plugin package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive plugin packaging and documentation only; no changes to core marketplace runtime or existing plugins beyond new index entries.
> 
> **Overview**
> Adds a new **Falconer** Cursor plugin so agents can read, search, and update Falconer documents via **hosted HTTP MCP** at `https://falconer.com/api/mcp` (no local stdio transport).
> 
> The `falconer/` package includes `plugin.json`, `mcp.json`, Apache-2.0 `LICENSE`, a short README, and the **falconer-knowledge** skill with editing rules (preserve `![f>]` references, prefer targeted edits, confirm destructive actions) plus a **falconer-formatting** reference for Falconer Markdown and rich blocks.
> 
> **Falconer** is registered in `.cursor-plugin/marketplace.json` and the root `README.md` plugins table (Productivity / Falconer AI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46108ded5de4909b7e22581507ef85f7cf1d69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->