### PR TITLE
poteto-mode: add the Hillclimb playbook

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -109,6 +109,7 @@ A large or cross-cutting effort (a migration across many call sites, an ambitiou
 - **Investigation.** Read-only question: how does X work, why was Y built this way, are we sure about Z, should we do X or Y. `playbooks/investigation.md`.
 - **Bug fix.** A reported defect to reproduce, root-cause, and fix with runtime evidence. `playbooks/bug-fix.md`.
 - **Perf issue.** A measured slowness to trace and improve against a baseline. `playbooks/perf-issue.md`.
+- **Hillclimb.** Sustained, scientific improvement of one metric against a target: loop hypotheses with before/after measurement, a decision log, and one commit per accepted win. Distinct from Perf issue, which is a one-off fix. `playbooks/hillclimb.md`.
 - **Runtime forensics.** Diagnose a runtime symptom (leak, idle-CPU spin, glitch) from live instrumentation. The deliverable is a diagnosis, not a fix. `playbooks/runtime-forensics.md`.
 - **Trace forensics.** Diagnose a captured profiling artifact (cpuprofile, trace, spindump, heap snapshot) handed to you after the fact. The deliverable is a diagnosis, not a fix. `playbooks/trace-forensics.md`.
 - **Feature.** New or changed behavior, built from a named data shape. `playbooks/feature.md`.

--- a/pstack/skills/poteto-mode/playbooks/hillclimb.md
+++ b/pstack/skills/poteto-mode/playbooks/hillclimb.md
@@ -1,0 +1,21 @@
+### Hillclimb
+
+**You own the metric and the experiment's integrity. Supervise and review; delegate the attempts.** For sustained, iterative improvement of one measurable thing against a target ("hillclimb on X", "make startup 50% faster", "systematically drive down <metric>", "keep trying until <metric> improves by N%"). A one-off fix is Bug fix or Perf issue; this is the loop.
+
+Core discipline: one change, one measurement, keep or revert. Never stack untested changes, and never claim a win from code inspection. The data decides (the **prove-it-works** principle skill).
+
+1. Fix the metric and the stop predicate before the first attempt. One number, the direction that counts as better, and a checkable predicate that pairs a target with a floor on attempts so a lucky early win can't end the run (the example "at least 50% better than baseline and at least 10 iterations" is this shape). Use the user's numbers when given, otherwise agree them. A vague goal spins; a predicate lets you stop.
+2. Build the measurement harness, then freeze it (the **build-the-lever** principle skill). One repeatable command that emits the metric, sampled enough to clear the noise (median of N, not a single run). It is the ruler, so once it produces the baseline it is immutable; changing it mid-run invalidates every earlier number. Record the baseline metric and a green run of the regression gate (the tests that must keep passing) before any change.
+3. Open the decision log via the **show-me-your-work** skill. A `decision.tsv`, one row per attempt: id, hypothesis, change, before, after, delta, tests, verdict (kept or reverted), note. This is the run's memory. Read it before each attempt so the search accumulates instead of circling. Keep it out of the tree (gitignored) so it survives reverts.
+4. Ground hypotheses in the real architecture before guessing. Run the **how** skill over the target once, up front, so each attempt names a specific mechanism ("defer X off the boot path because it blocks first paint"), not "try memoizing something".
+5. Loop, one hypothesis per iteration:
+   - Hand the change to a subagent using your configured hillclimb model (default `gpt-5.5-high-fast`) with a tight scope; supervise and review the diff rather than typing it (the **guard-the-context-window** principle skill). When several independent hypotheses are live, fan them to parallel subagents, each in its own worktree so they can't collide (the **separate-before-serializing-shared-state** principle skill).
+   - Measure before and after with the frozen harness, and run the regression gate.
+   - Accept only when the metric moves past noise and the gate stays green. Otherwise revert the change in full; a tweak that "might help" does not ride along.
+   - One commit per accepted fix, staging only the files you changed (`git add <files>`, never `-A`). Log the row either way, kept or reverted.
+   Each iteration ends in a check before the next begins (the **sequence-verifiable-units** principle skill). If the run is unattended, drive the wake loop per the Autonomous run playbook (`playbooks/autonomous-run.md`).
+6. Push past the first plateau. On a stall, several rejects in a row, pivot category, combine near-misses, re-read the source, or try something more radical before concluding the hill is climbed. Correctness and simplicity outrank the number. Revert a win that breaks behavior, and keep a simplification that holds the number (the **laziness-protocol** principle skill).
+7. Stop when the predicate is met, or when the remaining ideas are genuinely marginal and not worth their cost. Don't relax the predicate to declare victory, and don't quit while cheap untried hypotheses remain. If you are stuck, surface it instead of spinning.
+8. Run **Opening a PR** with the accepted commits stacked in the order they landed, so the metric's climb reads top to bottom.
+
+**Reply:** the metric and target, baseline to final with the percent delta, iterations run (kept vs reverted), each accepted fix on one line, the `decision.tsv` path, and the best idea you would try next if pushed further.

--- a/pstack/skills/poteto-mode/playbooks/perf-issue.md
+++ b/pstack/skills/poteto-mode/playbooks/perf-issue.md
@@ -10,4 +10,6 @@
 5. Cite the measurement in the PR.
 6. Run **Opening a PR**.
 
+For sustained improvement against a metric rather than a one-off fix, use the Hillclimb playbook (`playbooks/hillclimb.md`).
+
 **Reply:** baseline number, post-fix number, delta, artifact path.


### PR DESCRIPTION
## Summary
- New `playbooks/hillclimb.md`: a generic, metric-agnostic scientific hill-climb loop. Fix a metric and a stop predicate (a target paired with a floor on attempts so a lucky early win can't end the run), freeze a measurement harness, keep a `decision.tsv`, and loop one hypothesis at a time with before/after measurement, a regression gate, and one commit per accepted win. The agent supervises and delegates each attempt to subagents.
- Registered in the poteto-mode playbook list next to Perf issue, as the sustained-loop counterpart to that one-off playbook.
- `perf-issue.md` now points at Hillclimb for sustained work.

## Test plan
- [x] All referenced principle and skill links resolve on main (including `sequence-verifiable-units`).
- [x] No em-dash characters; matches poteto-mode voice and the configured-model delegation convention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill playbooks; no runtime code, auth, or data paths.
> 
> **Overview**
> Adds a **Hillclimb** agent playbook for sustained, metric-driven optimization (as opposed to one-off **Perf issue** work). The new `playbooks/hillclimb.md` defines an experiment loop: fix metric and stop predicate, freeze a measurement harness, maintain a gitignored `decision.tsv`, ground hypotheses with **how**, then iterate one change at a time with before/after measurement, a regression gate, revert-or-keep, and one commit per accepted win, with subagent delegation and optional parallel worktrees.
> 
> `SKILL.md` registers Hillclimb in the playbook list (next to Perf issue). `perf-issue.md` now points sustained metric work at Hillclimb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45bbdd154494295b65873d9b01d27707eb12b187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->