### PR TITLE
pstack: bump to 0.9.1 and list the hillclimb playbook in the README

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -32,13 +32,14 @@ use `/poteto-mode` at the start of a task. it reads your request, picks from a s
 
 ### just use `/poteto-mode`
 
-this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with fifteen playbooks:
+this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with sixteen playbooks:
 
 | playbook | for |
 |---|---|
 | investigation | a read-only question. how does x work, why was y built this way, are we sure. |
 | bug fix | reproduce a defect, root-cause it, and fix with runtime evidence. |
 | perf | trace a measured slowness and improve it against a baseline. |
+| hillclimb | sustained, scientific improvement of one metric against a target, looping hypotheses with before/after measurement and one commit per accepted win. |
 | runtime forensics | diagnose a live symptom (leak, idle-cpu spin, glitch) from instrumentation. |
 | trace forensics | diagnose a captured profiling artifact (cpuprofile, trace, spindump, heap snapshot). |
 | feature | new or changed behavior, built from a named data shape. |


### PR DESCRIPTION
## Summary
Housekeeping follow-up to #132, which added the Hillclimb playbook but did not touch the version or README.
- Bump the plugin patch version `0.9.0` -> `0.9.1`.
- README: count goes from fifteen to sixteen playbooks, and a `hillclimb` row is added next to `perf`.

## Test plan
- [x] README playbook table now lists hillclimb; count matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or skill behavior changes in this diff.
> 
> **Overview**
> **Release housekeeping** after the Hillclimb playbook landed elsewhere: bumps the pstack plugin version from **0.9.0** to **0.9.1** in `plugin.json`.
> 
> The **README** now matches shipped playbooks: the `/poteto-mode` count goes from fifteen to **sixteen**, and a new **`hillclimb`** row is added (after `perf`) describing sustained, measured improvement of one metric with one commit per accepted win.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c54e38925b752d4a6f59ec1629bb26c9819257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->