### PR TITLE
pstack: route hardest tasks to claude-fable-5-thinking-max

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -79,7 +79,7 @@ Read the leaf skill in full for any principle you apply. Each entry names when i
 
 **Use `subagent_type: "poteto-agent"` for any subagent you spawn inside a playbook step** (code-writing delegates, ad-hoc helpers). `/poteto-mode` and `poteto-agent` route through the same wrapper. Routed workflow skills (`how`, `why`, `interrogate`, `reflect`) set their own `subagent_type` for diverse-model review; respect what the skill prescribes, don't override to `poteto-agent`.
 
-**Defaults for every `Task` call.** `run_in_background: true`, agent mode (readonly strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; defaults `grok-4.5-fast-xhigh` for code, `claude-opus-4-8-thinking-xhigh` for prose and judgment).
+**Defaults for every `Task` call.** `run_in_background: true`, agent mode (readonly strips MCP), file pointers not inlined context, explicit model per role (configurable via `/setup-pstack`; defaults `grok-4.5-fast-xhigh` for code, `claude-opus-4-8-thinking-xhigh` for prose and judgment). The hardest changes (cross-cutting design, gnarly concurrency, subtle algorithms, vague intent) go to `claude-fable-5-thinking-max`.
 
 You own every subagent's work. Review the diff and write your own summary, don't pass through what it said. Interrupt-chained resumes silently drop directives, so fire a fresh subagent with consolidated scope rather than trusting a "done" summary. A second opinion is the same prompt against a different model. Agreement is high-signal.
 

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -40,6 +40,7 @@ bug-fix: gpt-5.5-high-fast
 perf-issue: gpt-5.5-high-fast
 hillclimb: gpt-5.5-high-fast
 judgment and prose: claude-opus-4-8-thinking-xhigh
+hardest tasks: claude-fable-5-thinking-max
 how explorer: grok-4.5-fast-xhigh
 how explainer: claude-opus-4-8-thinking-xhigh
 how critics: claude-opus-4-8-thinking-xhigh, gpt-5.5-high-fast, grok-4.5-fast-xhigh


### PR DESCRIPTION
## Summary
- Adds a hardest-tasks tier to poteto-mode's Task-call defaults: cross-cutting design, gnarly concurrency, subtle algorithms, and vague intent go to `claude-fable-5-thinking-max` (mirrors the private setup's routing; deliberately no Sol tier here).
- Adds a matching `hardest tasks:` role line to the setup-pstack defaults rule so `/setup-pstack` users can override it.
- Bumps pstack to 0.10.2.

## Test plan
- [x] Only public model slugs referenced (Fable is a public Claude model)
- [x] Grep confirms the new role line renders in the setup-pstack rule shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Skill and plugin metadata only; no application runtime or security-sensitive code paths change.
> 
> **Overview**
> Adds a **hardest-tasks** model tier to pstack so the heaviest work (cross-cutting design, gnarly concurrency, subtle algorithms, vague intent) defaults to `claude-fable-5-thinking-max` on `Task` subagent calls, alongside the existing code and judgment defaults.
> 
> **setup-pstack** gains a matching `hardest tasks:` line in the generated `pstack-models.mdc` template so users can override that role. Plugin version is bumped to **0.10.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f43ff661bbe07052cca70609521e6c38bb5ceae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->