### PR TITLE
pstack: make poteto-mode a sticky mode with a conditional reminder

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 mode: true
 icon: crown
 color: yellow
-reminder: New task? Playbook match or rigor needed -> apply the poteto-mode skill. Casual turn or user opts out -> don't.
+reminder: New task? Playbook match or rigor needed -> apply /poteto-mode. Casual turn or user opts out -> don't.
 ---
 
 # Poteto mode

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -2,6 +2,10 @@
 name: poteto-mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
+mode: true
+icon: crown
+color: yellow
+reminder: New task? Playbook match or rigor needed -> apply the poteto-mode skill. Casual turn or user opts out -> don't.
 ---
 
 # Poteto mode


### PR DESCRIPTION
## Summary
- Adds custom-mode frontmatter to poteto-mode (`mode: true`, `icon: crown`, `color: yellow`, `reminder:`), so entering /poteto-mode persists across turns: the full skill body injects on entry, and the reminder line injects on each later turn.
- The reminder is deliberately conditional rather than "stay in mode": it gates on a task boundary, applies the skill only on a playbook match or when rigor is needed, and stands down on casual turns and explicit opt-outs — so mid-task "keep going" turns don't re-enter the mode and casual questions don't get ceremony. The wording won a 5-candidate × 4-scenario behavioral eval (blind judge, transcript-verified conduct); "stay in mode" style reminders countermand explicit opt-outs, and per-turn self-check questions induce full re-entry on continuations.
- The reminder references the skill by name (not a repo path) since pstack installs as a plugin.
- Bumps pstack to 0.10.3.

## Test plan
- [x] No internal references (grep clean)
- [ ] Enter /poteto-mode in a fresh session with pstack installed: mode pill renders (crown/yellow), reminder injects on subsequent turns

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plugin skill metadata and version bump only; no runtime app logic, auth, or data handling.
> 
> **Overview**
> **Turns `/poteto-mode` into a sticky Cursor mode** by adding custom-mode frontmatter on the skill (`mode: true`, `icon: crown`, `color: yellow`). After entry, the full skill still injects once; later turns get a short **reminder** line instead of re-injecting the whole body.
> 
> The reminder is **conditional**, not “always stay in mode”: re-apply `/poteto-mode` on a new task when a playbook matches or rigor is needed; skip on casual turns or explicit opt-out. It names the skill (`/poteto-mode`) for plugin installs, not a repo path.
> 
> **pstack** version bumps **0.10.2 → 0.10.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acbcd0e157fef146035bee9bfb82f98739e42bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->