### PR TITLE
pstack: add model-the-domain principle; true up README

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.10.3",
+	"version": "0.10.4",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -68,6 +68,8 @@ when invoked it:
 
 the full rules and playbooks live in `skills/poteto-mode/SKILL.md`.
 
+`/poteto-mode` is also a sticky mode: once entered it stays on across turns, applying itself when a playbook matches or the task needs rigor and staying out of the way otherwise. opt out any time by saying so.
+
 `/poteto-mode` works extremely well with cursor's `/loop` command. you can make cursor work for many hours without sacrificing rigor.
 
 ## skills
@@ -83,7 +85,7 @@ the rest are useful when you want to specifically invoke them:
 | `/blast-radius` | you have a small-looking change and want to know what else it could break, with the one fact it's safe because of proven by running code, not asserted. |
 | `/architect` | you're about to write code that crosses a function boundary and want the caller's usage, types, and module shape settled first. |
 | `/arena` | you want N parallel attempts at the same thing, then to grab the best parts of each. |
-| `/interrogate` | you have a diff and want four different models to try to break it, including a strict code-quality lens. |
+| `/interrogate` | you have a diff and want several different models to try to break it, including a strict code-quality lens. |
 | `/automate-me` | you want your own `-mode` skill, drafted from how you've actually worked. |
 | `/setup-pstack` | you want to pick which models pstack uses per role. detects your models and writes a config rule. |
 | `/reflect` | a long task landed and you want the recipe captured as a skill edit. |
@@ -137,10 +139,10 @@ pstack also ships a subagent that runs my style end to end. spawn it from a pare
 
 ## principles
 
-twenty short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
+twenty-one short skills, one principle each. `poteto-mode` indexes them inline and reads that index at task start. the standalone files are there so other skills can reference a principle by name, and so the index can point at the full rule for each.
 
 - core: laziness-protocol, foundational-thinking, redesign-from-first-principles, subtract-before-you-add, minimize-reader-load, outcome-oriented-execution, experience-first, exhaust-the-design-space, build-the-lever.
-- architecture: boundary-discipline, type-system-discipline, make-operations-idempotent, migrate-callers-then-delete-legacy-apis, separate-before-serializing-shared-state.
+- architecture: model-the-domain, boundary-discipline, type-system-discipline, make-operations-idempotent, migrate-callers-then-delete-legacy-apis, separate-before-serializing-shared-state.
 - verification: prove-it-works, fix-root-causes, sequence-verifiable-units.
 - delegation: guard-the-context-window, never-block-on-the-human.
 - meta: encode-lessons-in-structure.

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -48,6 +48,7 @@ Read the leaf skill in full for any principle you apply. Each entry names when i
 
 **Architecture**
 
+- **Model the Domain** (**principle-model-the-domain**). Writing stateful logic, or code that branches a lot or repeats a shape assumption across files. Encode the domain in a structure (state machine, typed model, table or registry, reducer, boundary, the right collection) instead of scattered conditionals.
 - **Boundary Discipline** (**principle-boundary-discipline**). Wiring validation, error handling, or framework adapters. Guards at system boundaries, trust internal types, keep business logic pure.
 - **Type System Discipline** (**principle-type-system-discipline**). Designing types or a signature in any typed language. Make illegal states unrepresentable, brand primitives, parse external data at boundaries.
 - **Make Operations Idempotent** (**principle-make-operations-idempotent**). Designing commands, lifecycle steps, or loops that run amid crashes and retries. Converge to the same end state.

--- a/pstack/skills/principle-model-the-domain/SKILL.md
+++ b/pstack/skills/principle-model-the-domain/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: principle-model-the-domain
+description: "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the domain in a structure instead of scattered conditionals."
+disable-model-invocation: true
+---
+
+# Model the Domain
+
+Encode the real domain in a data structure instead of scattering it across conditionals.
+
+**Why:** Scattered booleans, repeated shape assumptions, and branching spread across files are accidental complexity. A structure that matches the domain makes invalid states unrepresentable and deletes branches. Choosing it at write time is cheap; recovering it later reads as a refactor and gets deferred.
+
+**Pattern — reach for:**
+
+- A state machine instead of scattered booleans, phases, or lifecycle checks.
+- A typed object/model instead of loose parameters or repeated shape assumptions.
+- A map, registry, lookup table, or discriminated union instead of branching spread across files.
+- A reducer or command/event model instead of ad hoc state mutations.
+- A small module boundary that gathers repeated behavior, ownership, or invariants.
+- A queue, cache, index, graph/tree, or normalized collection where the data access pattern calls for it.
+- Any other structure that fits. The list above covers the common cases only. When none fits, work out what the code must never allow and how the data gets read, then find the structure that encodes exactly that.
+
+Do not force an abstraction. Prefer boring code if the current shape is already clear, local, and unlikely to grow. Be skeptical of an abstraction that adds indirection without removing branches, duplicated rules, invalid states, or lifecycle risk.
+
+The tell that you skipped this: a new feature that grows an existing if/else chain by one more branch, or a second boolean that must stay in sync with the first.


### PR DESCRIPTION
## Summary
- New principle skill `principle-model-the-domain`: encode the domain in a structure (state machine, typed model, lookup table/registry, reducer, module boundary, the right collection — or whatever structure the invariants ask for) instead of scattered conditionals, applied while writing code. Includes the do-not-force guard and the tell (a feature that grows an if/else chain by one more branch). Chosen by a 5-encoding × 2-task × 2-model eval: write-time encodings beat both baseline and a post-hoc review skill, which made agents correctly decline the reshape as scope creep.
- README trued up against actual state: principles count twenty → twenty-one with the new architecture entry; the `/interrogate` row said "four different models" while the skill's default list is three (now count-agnostic); added a line documenting that `/poteto-mode` is a sticky mode since #144. Model slugs were already current (no stale composer-2.5-fast anywhere).
- Version 0.10.3 → 0.10.4.

## Test plan
- [x] Leak check clean (no internal names/paths in the new skill or README)
- [x] Skill body is a faithful copy of the merged everysphere leaf (no path references needed rewriting — the leaf is self-contained)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and plugin metadata only; no application logic or production data-shape assumptions.
> 
> **Overview**
> Adds a new architecture principle skill **`principle-model-the-domain`**, which tells agents to encode stateful or heavily branching domain logic in explicit structures (state machines, typed models, registries, reducers, boundaries, etc.) instead of scattered conditionals, with guidance not to over-abstract and a concrete “tell” when the principle was skipped.
> 
> The principle is wired into **`poteto-mode`**’s inline Architecture index and the README principles list (count **twenty-one**; **model-the-domain** listed under architecture). README also documents **`/poteto-mode` as a sticky mode**, softens **`/interrogate`** copy from “four different models” to count-agnostic “several,” and bumps **`plugin.json`** to **0.10.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1beebee1a8712455bc6078503674178f82bcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->