### PR TITLE
pstack: give poteto-mode a human display name

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: poteto-mode
+name: Poteto Mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
 mode: true


### PR DESCRIPTION
## Summary
- Sets `name: Poteto Mode` in poteto-mode's frontmatter. The name field is the display label in the slash menu; skill identity and /poteto-mode resolution derive from the folder path, so routing is unchanged. Unquoted bare string, same pattern as similar display names elsewhere.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single frontmatter label change with no runtime, routing, or data logic.
> 
> **Overview**
> Updates the `name` field in `poteto-mode` skill frontmatter from `poteto-mode` to **Poteto Mode** so the slash menu shows a readable label.
> 
> Skill routing still uses the folder path and `/poteto-mode`; only the UI display string changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ac966ade58d248ae895683debe25233638b3e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->