### PR TITLE
pstack: add the teach skill; bump to 0.11.1

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
## Summary
- Adds `/teach`: explains a change or subsystem plainly by running `how` + `why` and weaving one explanation — plain-definition-first, conversation not lecture, diagram-by-diagram build-up for anything with 3+ moving parts, unslop-clean prose. Ported verbatim from the private version, which had absorbed all iterations from the earlier closed port attempt (#127) plus newer rules (incremental diagrams, one-name-per-concept). Scrub-clean: no internal names, paths, or model slugs (verified; its `how`/`why`/`unslop` references all resolve in pstack).
- README row for `/teach`.
- Version 0.11.0 → 0.11.1 (also covers #151's live-pass hardening).