### PR TITLE
pstack: bump version to 0.11.2

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.11.1",
+	"version": "0.11.2",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"


### PR DESCRIPTION
Patch bump for the /teach skill that landed in #153 after the 0.11.1 bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version field update in plugin metadata with no runtime or security impact.
> 
> **Overview**
> Bumps the **pstack** Cursor plugin release version in `plugin.json` from **0.11.1** to **0.11.2**.
> 
> This is a metadata-only patch release to align the published plugin version with the `/teach` skill changes that shipped separately (e.g. after #153), not a change to plugin behavior in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226bbcbc2a735ea639ffe4958384a95ce2423f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->