### PR TITLE
poteto-mode: give the perf playbook its eight strategy families

### DIFF
--- a/pstack/skills/poteto-mode/playbooks/perf-issue.md
+++ b/pstack/skills/poteto-mode/playbooks/perf-issue.md
@@ -4,6 +4,15 @@
 
 1. Capture a baseline trace via the matching control skill.
 2. `how` to ground hypotheses; don't claim a perf ceiling without running it first.
+   Most fixes come from eight strategy families. Use them as hypothesis generators, not a checklist. A family earns an attempt only when the trace shows the signal it names, and a focused fix for the dominant cost beats applying all eight.
+   - **Elimination.** The cheapest work is work that doesn't run. Before optimizing the hot path, ask whether it needs to exist: a computation nobody consumes, a feature gate that's always off for this user, a sync that redundantly mirrors state, a legacy path kept "just in case". The trace shows what's slow, never that it's deletable, so this family needs the `how` pass, not the profiler. Deleting the work beats every other family when it applies.
+   - **Divide and conquer.** The dominant cost scales with input size. Split the work so each piece touches less (chunk, shard, prune the search space) or so independent pieces run in parallel.
+   - **Caching.** The same computation or fetch repeats on identical inputs. Store and reuse the result; name what invalidates it before claiming the win.
+   - **Indirection.** The hot path does expensive work a cheaper intermediate could absorb: an index instead of a scan, a queue that shifts work off the interactive thread, a handle that lets a cheaper implementation swap in. Add the hop only when it removes more from the critical path than it adds; a layer that sits on the hot path without removing work is pure cost.
+   - **Batching.** Many small operations each pay a fixed overhead (RPC, query, syscall, draw call). Coalesce them to pay the overhead once per batch.
+   - **Redundancy.** The wait hangs on one slow instance or attempt. Duplicate the work (replicas, hedged requests, speculative execution) and take the fastest result. This trades extra load for lower tail latency, so the trace has to show the wait dominates and the system has headroom; duplication without that tradeoff only adds load.
+   - **Lazy evaluation.** Cost lands on results that are never used or not needed yet (eager init on the boot path, rendering offscreen items). Defer the work until first use.
+   - **Scheduling.** The work must happen, but not during the interactive moment. Move it to where nobody is waiting: idle callbacks, a background warmup after boot, precompute before the user arrives, cleanup after the frame commits. Distinct from Lazy (later-when-needed): Scheduling often runs the work *earlier* than the hot moment, or in its shadow. The win is perceived latency, so measure the interactive path, not total work done.
 3. Plan the fix from the trace. If it crosses a function boundary, `architect` first. Delegate implementation to a subagent using your configured perf-issue model (default `gpt-5.5-high-fast`); review the diff. Capture a post-fix trace.
    Apply the **sequence-verifiable-units** principle skill, verifying each attempt before trying the next.
 4. Parse and compare the artifacts (JSON to sqlite, diff). "Inconclusive" or wrong-surface is not a pass; flag it.


### PR DESCRIPTION
## Summary
- The public perf playbook never received the strategy-families list that the private version's step 2 carries — its step 2 was a single line. This ports the full list at current parity: the six original families (divide-and-conquer, caching, indirection, batching, redundancy, lazy) plus the two just added upstream after checking the playbook against Hanson/Crain's performance mantras (anysphere/everysphere#168492):
  - **Elimination** ("don't do it") — leads the list; the one family a trace can't surface, so it rides the `how` pass.
  - **Scheduling** ("do it when they're not looking") — after Lazy, with the Lazy-vs-Scheduling distinction spelled out; measured on perceived latency.
- Text is verbatim from the private playbook minus one internal skill-path reference (already absent in the public step structure). Leak check clean.
- Deliberately NOT touched: the playbook's `gpt-5.5-high-fast` default — it's pstack's current configured default across 13 files, and model routing changes are their own PRs.

## Test plan
- [x] Leak check clean
- [x] Step numbering and reply contract unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only playbook text; no runtime, routing, or measurement pipeline changes.
> 
> **Overview**
> Expands **step 2** of the public `perf-issue` playbook from a single `how`/trace line into the full **eight strategy families** list used upstream, framed as trace-driven hypothesis generators (not a checklist).
> 
> Adds **Elimination** (work that may not need to run; needs the `how` pass, not only the profiler) and **Scheduling** (move work off the interactive moment, with Lazy vs Scheduling and perceived-latency measurement called out), alongside the six existing families: divide-and-conquer, caching, indirection, batching, redundancy, and lazy evaluation. Step numbering, measurement workflow, and the reply contract are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0785e1b11cff8bbd76c6d429d8d6e9a6c9d7acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->