### PR TITLE
fix-root-causes: paragraph-long workaround comments are a tell

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.11.3",
+	"version": "0.11.4",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/skills/principle-fix-root-causes/SKILL.md
+++ b/pstack/skills/principle-fix-root-causes/SKILL.md
@@ -14,6 +14,7 @@ When debugging, do not paper over symptoms. Trace every problem to its root caus
 - Reproduce first (if you can't reproduce it, you can't verify your fix)
 - Ask "why" until you hit the root cause
 - Resist the urge to add guards (adding a nil check to silence a crash is a symptom fix)
+- If a workaround needs a paragraph-long comment to justify it, the code is wrong (fix the code, not the comment)
 - Check for the pattern, not just the instance (grep for the same pattern, fix all instances)
 - When stuck, instrument. Don't guess (add logging, read the actual error)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds “If a workaround needs a paragraph-long comment to justify it, the code is wrong (fix the code, not the comment)” to the `principle-fix-root-causes` Pattern list after the guard guidance.

This mirrors the private upstream skill tree. The pstack version is bumped to 0.11.4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51e9e1f4-0bf0-498b-a56d-3a77b35a1612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51e9e1f4-0bf0-498b-a56d-3a77b35a1612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

