### PR TITLE
pstack: explorers default to grok

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.11.6",
+	"version": "0.11.7",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/skills/how/SKILL.md
+++ b/pstack/skills/how/SKILL.md
@@ -45,7 +45,7 @@ The right decomposition depends on the question. Use your judgment. Narrow quest
 Spawn all explorers in a single message:
 
 - `subagent_type`: `generalPurpose`
-- `model`: resolve the configured `how explorer` role per `~/.cursor/rules/pstack-models.mdc`. Pass a real slug as `model`. Omit `model` for `inherit-parent`/`auto`. If the role line is absent, default to `gpt-5.6-sol-max`.
+- `model`: resolve the configured `how explorer` role per `~/.cursor/rules/pstack-models.mdc`. Pass a real slug as `model`. Omit `model` for `inherit-parent`/`auto`. If the role line is absent, default to `grok-4.5-fast-xhigh`.
 - `readonly`: `true`
 
 Each explorer gets the same base prompt from `references/explorer-prompt.md` plus a specific exploration angle naming its slice. Each explorer should:

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -48,10 +48,10 @@ perf-issue: gpt-5.6-sol-max
 hillclimb: gpt-5.6-sol-max
 judgment and prose: claude-fable-5-thinking-max
 hardest tasks: claude-fable-5-thinking-max
-how explorer: gpt-5.6-sol-max
+how explorer: grok-4.5-fast-xhigh
 how explainer: claude-fable-5-thinking-max
 how critics: claude-fable-5-thinking-max, gpt-5.6-sol-max, grok-4.5-fast-xhigh
-why investigators: gpt-5.6-sol-max
+why investigators: grok-4.5-fast-xhigh
 why synthesizer: claude-fable-5-thinking-max
 reflect tooling: gpt-5.6-sol-max
 reflect judgment, divergent, synthesizer: claude-fable-5-thinking-max

--- a/pstack/skills/why/SKILL.md
+++ b/pstack/skills/why/SKILL.md
@@ -117,7 +117,7 @@ Launch all matching investigators in a single message so they run concurrently. 
 
 Subagent config (each):
 - `subagent_type`: `generalPurpose`
-- `model`: resolve the configured `why investigators` role per `~/.cursor/rules/pstack-models.mdc`. Pass a real slug as `model`. Omit `model` for `inherit-parent`/`auto`. If the role line is absent, default to `gpt-5.6-sol-max`.
+- `model`: resolve the configured `why investigators` role per `~/.cursor/rules/pstack-models.mdc`. Pass a real slug as `model`. Omit `model` for `inherit-parent`/`auto`. If the role line is absent, default to `grok-4.5-fast-xhigh`.
 - `readonly`: `false` (agent mode). **Do not use readonly/Ask mode.** It strips MCP access, which disables MCP-backed investigators entirely. The source control investigator would be safe in readonly, but keep modes uniform. Investigators still shouldn't write anything. That's a posture, not a sandbox.
 
 Each investigator gets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- default `how explorer` and `why investigators` roles to `grok-4.5-fast-xhigh`
- preserve existing explainer, synthesizer, panel, bug-fix, performance, hillclimb, and reflect defaults
- bump pstack from 0.11.6 to 0.11.7

## Verification
- confirmed setup rule examples use Grok
- confirmed absent-line defaults use Grok
- confirmed bug-fix, perf-issue, and hillclimb remain `gpt-5.6-sol-max`
- confirmed the diff contains only the four requested files and passes `git diff --check`
- confirmed local, pushed, and PR head SHA all equal `0520767bf76f0e8d99841ebb8a0346233e8cee17`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af9aeb50-4157-41f0-aa71-843c92cdafe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af9aeb50-4157-41f0-aa71-843c92cdafe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

