### PR TITLE
unslop: flag load-bearing and gate as AI tells

### DIFF
--- a/pstack/skills/unslop/SKILL.md
+++ b/pstack/skills/unslop/SKILL.md
@@ -69,7 +69,7 @@ Removing patterns is half the job. Sterile, voiceless writing is just as obvious
 
 ### Jargon
 
-26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". Pick the concrete word.
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, load-bearing, gate (as metaphor: "gate this", "gating"). These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Load-bearing" and "gate" are far overused by AI compared to how humans write, and they make text obviously AI generated. "Load-bearing" becomes "critical", "required", or name what depends on it. "Gate" becomes "block", "require approval for", or "hide behind a flag". Pick the concrete word.
 
 ### Plain speech
 


### PR DESCRIPTION
Thought this might be a helpful addition.

We joke about this at my workplace. I always say: if you see the phrase "load bearing" in a PR or documentation or something, it was written by AI. 100%. 😂 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an editing skill; no runtime or security impact.
> 
> **Overview**
> Extends **abstract metaphor nouns** (pattern 26) in the `unslop` skill with **load-bearing** and metaphorical **gate** / **gating**, plus plain-language replacements (**critical** / **required** vs **block** / **require approval for** / **hide behind a flag**).
> 
> Adds a short note that these terms are overused by AI relative to human writing, in line with the existing jargon list in `SKILL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848176b9d4ad6205586bd60440d3c86f8f5d527c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->