### PR TITLE
fix(thermos): Pass rubric paths to review subagents

### DIFF
--- a/thermos/.cursor-plugin/plugin.json
+++ b/thermos/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thermos",
   "displayName": "Thermos",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Thermo-nuclear branch review: deep correctness and security audits plus harsh code-quality rubrics, parallel subagents, thermos orchestration, and optional take-the-wheel and FSD merge-ready flows.",
   "author": {
     "name": "Cursor",

--- a/thermos/CHANGELOG.md
+++ b/thermos/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.1
+
+- Parents resolve and pass absolute rubric `SKILL.md` paths (or inlined bodies)
+  when spawning thermo review subagents.
+- Subagent agents prefer parent-provided rubrics and no longer instruct models
+  to search for or invoke thermos slash skills (Task subagents cannot execute
+  those).
+
 ## 1.0.0
 
 - Initial Thermos plugin release.

--- a/thermos/README.md
+++ b/thermos/README.md
@@ -56,8 +56,12 @@ flowchart TB
 **Double review (thermos):**
 
 1. Gather `git diff main...HEAD` and full contents of changed files.
-2. Invoke both subagents in one message with `run_in_background: true`.
-3. Synthesize prioritized, deduped findings.
+2. Resolve absolute paths to `skills/thermo-nuclear-review/SKILL.md` and
+   `skills/thermo-nuclear-code-quality-review/SKILL.md` (or inline those
+   bodies). Task subagents cannot invoke slash skills — pass the rubric path
+   or inlined content in each prompt.
+3. Invoke both subagents in one message with `run_in_background: true`.
+4. Synthesize prioritized, deduped findings.
 
 **Single skill:** invoke `thermo-nuclear-review` or `thermo-nuclear-code-quality-review` in the main agent, or the matching subagent after gathering diff context.
 

--- a/thermos/agents/thermo-nuclear-code-quality-review-subagent.md
+++ b/thermos/agents/thermo-nuclear-code-quality-review-subagent.md
@@ -1,16 +1,27 @@
 ---
 name: thermo-nuclear-code-quality-review-subagent
-description: Thermo-nuclear code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents. Loads rubric from the thermo-nuclear-code-quality-review skill in the Thermos plugin.
+description: Thermo-nuclear code quality audit (maintainability, structure, 1k-line rule, spaghetti, code-judo). Invoked via Task after a parent gathers diff and file contents and passes the thermo-nuclear-code-quality-review rubric path or inlined body.
 ---
 
 # Thermo-Nuclear Code Quality Review
 
-You are a **Task subagent**. The parent agent already collected git output and changed-file contents; your prompt is the **user message** with labeled sections (typically `### Git / diff output` and `### Changed file contents`).
+You are a **Task subagent**. The parent agent already collected git output and changed-file contents; your prompt is the **user message** with labeled sections (typically `### Git / diff output` and `### Changed file contents`, plus a rubric path or inlined rubric).
 
 ## Rubric
 
-1. Load the `thermo-nuclear-code-quality-review` skill (shipped in the Thermos plugin) and treat its `SKILL.md` as the **complete** rubric — tone, approval bar, output ordering, code-judo / 1k-line / spaghetti rules.
-2. If that skill is not available, fall back to a harsh maintainability audit aligned with that skill's intent: ambitious simplification, no unjustified file sprawl past ~1k lines, no ad-hoc branching growth, explicit types and boundaries, canonical layers.
+1. Prefer the rubric the parent already provided:
+   - If the prompt includes an absolute path to
+     `thermo-nuclear-code-quality-review/SKILL.md`, **Read that file** and treat
+     it as the **complete** rubric (tone, approval bar, output ordering,
+     code-judo / 1k-line / spaghetti rules).
+   - Else if the prompt includes a `### Rubric (inlined)` (or similar) section,
+     treat that body as the complete rubric.
+2. Do **not** search the filesystem for thermos / thermo-nuclear skills, and do
+   **not** try to invoke slash skills — Task subagents cannot execute those.
+3. Only if the parent provided neither a path nor an inlined rubric: fall back to
+   a harsh maintainability audit aligned with that skill's intent: ambitious
+   simplification, no unjustified file sprawl past ~1k lines, no ad-hoc
+   branching growth, explicit types and boundaries, canonical layers.
 
 ## Work
 
@@ -20,4 +31,4 @@ You are a **Task subagent**. The parent agent already collected git output and c
 
 ## Parent orchestration
 
-Typical flow: in **one** message, run two `Task` calls in parallel — `subagent_type: "shell"` and `subagent_type: "explore"` — to collect `git diff <base>...HEAD` output and full contents of changed files (default base `main`). Then invoke this agent with `subagent_type: "thermo-nuclear-code-quality-review-subagent"` and a user prompt containing `### Git / diff output` and `### Changed file contents`.
+Typical flow: in **one** message, run two `Task` calls in parallel — `subagent_type: "shell"` and `subagent_type: "explore"` — to collect `git diff <base>...HEAD` output and full contents of changed files (default base `main`). Resolve the absolute path to this plugin's `skills/thermo-nuclear-code-quality-review/SKILL.md` (or inline its body). Then invoke this agent with `subagent_type: "thermo-nuclear-code-quality-review-subagent"` and a user prompt containing `### Git / diff output`, `### Changed file contents`, and the rubric path or `### Rubric (inlined)`.

--- a/thermos/agents/thermo-nuclear-review-subagent.md
+++ b/thermos/agents/thermo-nuclear-review-subagent.md
@@ -1,16 +1,27 @@
 ---
 name: thermo-nuclear-review-subagent
-description: Thermo-nuclear branch audit (bugs, breaking changes, security, devex, feature-flag leaks) scoped to the diff. Invoked via Task after a parent gathers diff and file contents. Loads rubric from the thermo-nuclear-review skill in the Thermos plugin.
+description: Thermo-nuclear branch audit (bugs, breaking changes, security, devex, feature-flag leaks) scoped to the diff. Invoked via Task after a parent gathers diff and file contents and passes the thermo-nuclear-review rubric path or inlined body.
 ---
 
 # Thermo Nuclear Review (Deep review)
 
-You are a **Task subagent**. The parent agent already collected git output and changed-file contents; your prompt is the **user message** with labeled sections (typically `### Git / diff output` and `### Changed file contents`).
+You are a **Task subagent**. The parent agent already collected git output and changed-file contents; your prompt is the **user message** with labeled sections (typically `### Git / diff output` and `### Changed file contents`, plus a rubric path or inlined rubric).
 
 ## Rubric
 
-1. Load the `thermo-nuclear-review` skill (shipped in the Thermos plugin) and follow its `SKILL.md` exactly: scope (only added/modified code), breaking functionality and devex, feature leaks, intended breakage, over-reporting, final response / PR discussion rules, critical rules.
-2. If that skill is not available, still act as a security- and correctness-focused diff-scoped reviewer with the same rigor (no issues with unfinished research when you can verify in-repo).
+1. Prefer the rubric the parent already provided:
+   - If the prompt includes an absolute path to `thermo-nuclear-review/SKILL.md`, **Read that file** and follow it exactly.
+   - Else if the prompt includes a `### Rubric (inlined)` (or similar) section, follow that body exactly.
+2. Do **not** search the filesystem for thermos / thermo-nuclear skills, and do
+   **not** try to invoke slash skills — Task subagents cannot execute those.
+3. Only if the parent provided neither a path nor an inlined rubric: fall back to
+   a security- and correctness-focused diff-scoped review with the same rigor
+   (scope to added/modified code only; no issues with unfinished research when
+   you can verify in-repo).
+
+The rubric covers: scope (only added/modified code), breaking functionality and
+devex, feature leaks, intended breakage, over-reporting, final response / PR
+discussion rules, and critical rules.
 
 ## Work
 
@@ -25,4 +36,4 @@ Do **not** spawn nested subagents unless the user or parent explicitly asks.
 
 ## Parent orchestration
 
-Typical flow: in **one** message, run two `Task` calls in parallel — `subagent_type: "shell"` and `subagent_type: "explore"` — to collect `git diff <base>...HEAD` output and full contents of changed files (default base `main`). Then invoke this agent with `subagent_type: "thermo-nuclear-review-subagent"` and a user prompt containing `### Git / diff output` and `### Changed file contents`.
+Typical flow: in **one** message, run two `Task` calls in parallel — `subagent_type: "shell"` and `subagent_type: "explore"` — to collect `git diff <base>...HEAD` output and full contents of changed files (default base `main`). Resolve the absolute path to this plugin's `skills/thermo-nuclear-review/SKILL.md` (or inline its body). Then invoke this agent with `subagent_type: "thermo-nuclear-review-subagent"` and a user prompt containing `### Git / diff output`, `### Changed file contents`, and the rubric path or `### Rubric (inlined)`.

--- a/thermos/skills/thermos/SKILL.md
+++ b/thermos/skills/thermos/SKILL.md
@@ -12,10 +12,25 @@ Run the two thermo review passes as async background subagents in parallel, then
 
 1. Determine the review scope from the user request, PR, current branch, or relevant changed files.
 2. Gather the diff and any file/context excerpts needed for reviewers to evaluate the change without guessing.
-3. Launch both subagents in the same message with `run_in_background: true`:
+3. **Resolve rubric paths** before spawning. Task subagents cannot invoke slash
+   skills or discover plugin skill files reliably — never tell them to "load the
+   thermos skill". Resolve absolute paths to:
+   - `thermo-nuclear-review/SKILL.md` (security / correctness lens)
+   - `thermo-nuclear-code-quality-review/SKILL.md` (structure lens)
+   Search order (first existing file wins):
+   1. this plugin's `skills/<skill-name>/SKILL.md` (when you know the install path)
+   2. `$HOME/.claude/skills/<skill-name>/SKILL.md`
+   3. newest match under
+      `$HOME/.cursor/plugins/cache/cursor-public/thermos/*/skills/<skill-name>/SKILL.md`
+   Prefer passing the absolute path in each Task prompt. If a path is missing,
+   Read the rubric yourself and paste it under `### Rubric (inlined)` instead.
+4. Launch both subagents in the same message with `run_in_background: true`:
    - `subagent_type: "thermo-nuclear-review-subagent"` for bugs, breakages, security, devex regressions, feature-flag leaks, and other branch-audit risks.
    - `subagent_type: "thermo-nuclear-code-quality-review-subagent"` for maintainability, structure, file-size growth, spaghetti, abstractions, and codebase-health risks.
-4. Pass each subagent the same scoped diff/file context and ask it to return prioritized findings with file references and evidence.
-5. After both finish, synthesize the results with findings first, deduplicated across reviewers. Weight overlapping findings more heavily, resolve disagreements with your own judgment, and keep summaries brief.
+5. Pass each subagent the same scoped diff/file context **plus** that lens's
+   absolute rubric path (or inlined body). Instruct them to Read the path and
+   **not** search for or invoke thermos / thermo-nuclear skills. Ask for
+   prioritized findings with file references and evidence.
+6. After both finish, synthesize the results with findings first, deduplicated across reviewers. Weight overlapping findings more heavily, resolve disagreements with your own judgment, and keep summaries brief.
 
 If individual background summaries are already visible to the user, do not restate them wholesale. Surface the unified verdict, the highest-signal findings, and any remaining uncertainty.


### PR DESCRIPTION
## Summary
- Task subagents cannot execute `/thermos` or discover plugin skill files, so instructing them to "load the thermo-nuclear-* skill" wastes startup hunting for skills that never resolve.
- Parents (`thermos` skill / any orchestrator) now resolve absolute `SKILL.md` paths (or inline the rubric body) and pass them in each Task prompt.
- Subagent agent defs prefer parent-provided path / `### Rubric (inlined)` and explicitly forbid filesystem skill searches and slash-skill invocation.
- Bump Thermos to 1.0.1; document the parent contract in README and CHANGELOG.

## Test plan
- [ ] Invoke `/thermos` (or spawn both thermo review subagents) with a small branch diff
- [ ] Confirm subagents Read the provided rubric path and do not search for thermos skills at startup
- [ ] Confirm findings still reflect the security and code-quality rubrics
- [ ] Confirm fallback still works when parent omits path and inlined rubric (degraded but usable review)


Made with [Cursor](https://cursor.com)