### PR TITLE
Require Cursor 3.13.0 for the Google Workspace plugins

### DIFF
--- a/gmail/.cursor-plugin/plugin.json
+++ b/gmail/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "gmail",
   "displayName": "Gmail",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Gmail via Google's remote MCP server — search, read, draft, label, and manage email.",
   "author": {
     "name": "Cursor",

--- a/google-calendar/.cursor-plugin/plugin.json
+++ b/google-calendar/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "google-calendar",
   "displayName": "Google Calendar",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Google Calendar via Google's remote MCP server — list calendars, search events, and create or update meetings.",
   "author": {
     "name": "Cursor",

--- a/google-docs/.cursor-plugin/plugin.json
+++ b/google-docs/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "google-docs",
   "displayName": "Google Docs",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Google Docs via Google's remote MCP server — read and update documents.",
   "author": {
     "name": "Cursor",

--- a/google-drive/.cursor-plugin/plugin.json
+++ b/google-drive/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "google-drive",
   "displayName": "Google Drive",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Google Drive via Google's remote MCP server — search, read, create, share, and manage files.",
   "author": {
     "name": "Cursor",

--- a/google-sheets/.cursor-plugin/plugin.json
+++ b/google-sheets/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "google-sheets",
   "displayName": "Google Sheets",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Google Sheets via Google's remote MCP server — read spreadsheets, update values and formulas.",
   "author": {
     "name": "Cursor",

--- a/google-slides/.cursor-plugin/plugin.json
+++ b/google-slides/.cursor-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "google-slides",
   "displayName": "Google Slides",
   "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
   "description": "Connect Cursor to Google Slides via Google's remote MCP server — read and update presentations.",
   "author": {
     "name": "Cursor",

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -70,8 +70,31 @@
         "description": {
           "type": "string",
           "description": "Short description of the plugin."
+        },
+        "minClientVersions": {
+          "$ref": "#/$defs/minClientVersions",
+          "description": "Minimum client versions required to install the plugin, keyed by client identifier."
         }
       }
+    },
+    "minClientVersions": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "cursor": {
+          "$ref": "#/$defs/semver",
+          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\")."
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/semver",
+        "description": "Minimum version required for another client identifier."
+      }
+    },
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$",
+      "description": "Strict semantic version \"X.Y.Z\" with an optional prerelease suffix."
     }
   }
 }

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -25,6 +25,10 @@
       "type": "string",
       "description": "Semantic version of the plugin (e.g. \"1.2.3\")."
     },
+    "minClientVersions": {
+      "$ref": "#/$defs/minClientVersions",
+      "description": "Minimum client versions required to install the plugin, keyed by client identifier."
+    },
     "author": {
       "$ref": "#/$defs/author",
       "description": "The plugin author."
@@ -111,6 +115,25 @@
           "description": "Author email address."
         }
       }
+    },
+    "minClientVersions": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "cursor": {
+          "$ref": "#/$defs/semver",
+          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\")."
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/semver",
+        "description": "Minimum version required for another client identifier."
+      }
+    },
+    "semver": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$",
+      "description": "Strict semantic version \"X.Y.Z\" with an optional prerelease suffix."
     },
     "stringOrStringArray": {
       "oneOf": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The six Google Workspace plugins added in #179 depend on client behavior that only exists in Cursor 3.13.0 and newer. This sets `"minClientVersions": { "cursor": "3.13.0" }` on each of their manifests so older clients don't install them.

`schemas/plugin.schema.json` has `additionalProperties: false`, so the key had to be allowed in the schema first, otherwise `scripts/validate-plugins.mjs` rejects the manifests.

## Changes

- `schemas/plugin.schema.json`: new optional `minClientVersions` object keyed by client identifier. `cursor` is documented explicitly; other client identifiers are permitted and constrained to the same version format. Values must be strict semver `X.Y.Z` with an optional prerelease suffix, and the object must have at least one entry.
- `schemas/marketplace.schema.json`: same field added to the `pluginEntry` definition, which also has `additionalProperties: false`. No entries in `.cursor-plugin/marketplace.json` set it today; this only makes it expressible.
- `gmail/`, `google-calendar/`, `google-docs/`, `google-drive/`, `google-sheets/`, `google-slides/`: each `.cursor-plugin/plugin.json` now declares the 3.13.0 minimum.

## Verification

`node scripts/validate-plugins.mjs` passes. I also checked the schema directly against a handful of inputs: `3.13.0` and `3.13.0-beta.1` are accepted, and `3.13`, `v3.13.0`, an empty object, and a bare string are all rejected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f3c8e33-3094-4764-8be1-a93c1ed65ab2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f3c8e33-3094-4764-8be1-a93c1ed65ab2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

