### PR TITLE
Fix MCP servers not being discovered for Gong and Salesforce plugins

### DIFF
--- a/third_party/gong/mcp.json
+++ b/third_party/gong/mcp.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://cursor.com/schemas/mcp.json",
   "mcpServers": {
     "gong": {
       "url": "https://mcp.gong.io/mcp",

--- a/third_party/salesforce/mcp.json
+++ b/third_party/salesforce/mcp.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://cursor.com/schemas/mcp.json",
   "mcpServers": {
     "salesforce": {
       "type": "http",


### PR DESCRIPTION
## Summary

Removes `"$schema": "https://cursor.com/schemas/mcp.json"` from `third_party/gong/mcp.json` and `third_party/salesforce/mcp.json`.

After #191 merged and the repo reindexed, both plugins registered with **zero components** — their MCP servers were silently dropped. The `$schema` key is the cause.

## Root cause

`parsePluginMcpConfig` rejects the entire config when `mcp.json` declares a `$schema` that isn't locally recognized:

```ts
const mcpSchemaId = readSchemaId(data);
if (mcpSchemaId !== undefined) {
  if (resolveSchemaVersion(mcpSchemaId).kind === "unsupported") {
    return null;
  }
  ...
}
```

`SUPPORTED_SCHEMA_IDS` contains exactly two identifiers, both from the Agent Plugins 1.0.0 spec:

- `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`
- `https://agent-plugins.org/schemas/1.0.0/mcp.schema.json`

`https://cursor.com/schemas/mcp.json` is not one of them, so it resolves to `unsupported`, `parsePluginMcpConfig` returns `null`, and discovery records no MCP servers. The plugin still indexes fine — it just has nothing in it.

`gmail`, `google-drive`, and `google-calendar` omit `$schema` entirely, which is why they were unaffected and showed `1 component`.

Worth noting the URL is not bogus in general: `https://cursor.com/schemas/mcp.json` is the correct `$schema` for a *user's* `~/.cursor/mcp.json`. It just isn't valid for a plugin-owned `mcp.json`, which is governed by the Agent Plugins spec ids.

## Verification

Ran the real parser against both files, before and after:

```
gong (fixed)            -> [ "gong" ]
gong (as-merged)        -> NULL (0 servers)
salesforce (fixed)      -> [ "salesforce" ]
salesforce (as-merged)  -> NULL (0 servers)
```

`node scripts/validate-plugins.mjs` passes.

## Follow-up worth considering

`scripts/validate-plugins.mjs` did not catch this — it validates `plugin.json` and `marketplace.json` against the local JSON Schemas but never parses `mcp.json`. A plugin can therefore pass CI and index with its MCP servers silently discarded. A check that runs `parsePluginMcpConfig` over each plugin's declared `mcpServers` and fails when a plugin declares MCP but resolves to zero servers would have caught this at PR time. Happy to add it separately if that seems worthwhile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Third-party JSON-only change with no application code or auth flow modifications; restores intended MCP discovery behavior.
> 
> **Overview**
> **Gong** and **Salesforce** plugin MCP configs no longer declare `"$schema": "https://cursor.com/schemas/mcp.json"`. That URL is valid for user `~/.cursor/mcp.json` but is not in the Agent Plugins 1.0.0 supported schema list, so `parsePluginMcpConfig` was returning `null` and both plugins indexed with **zero** MCP components.
> 
> The server definitions (`mcpServers` entries, auth, URLs) are unchanged; only the schema line is removed, matching plugins like Gmail that never set `$schema`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01315dc14f6b4badfa07e04ca0de1b90fab48b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->