### PR TITLE
cursor-team-kit: add worktree + one-shot script cleanup rules

### DIFF
--- a/cursor-team-kit/README.md
+++ b/cursor-team-kit/README.md
@@ -47,6 +47,7 @@ Internal-style workflows for CI, code review, shipping, and test reliability. Th
 | `typescript-exhaustive-switch` | Require exhaustive switch handling for unions/enums |
 | `no-inline-imports` | Keep imports at module top-level for readability and consistency |
 | `worktree-cleanup` | Remove sibling git worktrees when their branch merges so parallel-work directories do not accumulate |
+| `one-shot-script-cleanup` | Delete `_tmp-*` helper scripts and temp payload files when the task that created them ships |
 
 ## License
 

--- a/cursor-team-kit/README.md
+++ b/cursor-team-kit/README.md
@@ -46,6 +46,7 @@ Internal-style workflows for CI, code review, shipping, and test reliability. Th
 |:-----|:------------|
 | `typescript-exhaustive-switch` | Require exhaustive switch handling for unions/enums |
 | `no-inline-imports` | Keep imports at module top-level for readability and consistency |
+| `worktree-cleanup` | Remove sibling git worktrees when their branch merges so parallel-work directories do not accumulate |
 
 ## License
 

--- a/cursor-team-kit/rules/one-shot-script-cleanup.mdc
+++ b/cursor-team-kit/rules/one-shot-script-cleanup.mdc
@@ -1,0 +1,72 @@
+---
+description: Delete one-shot helper scripts and temp payload files when the task that created them ships
+alwaysApply: true
+---
+
+# One-shot script cleanup
+
+Agent sessions often generate throwaway helper scripts and temp payload
+files to drive a single task -- claim a work item, extract one field
+from an API response, feed a CLI a file it insists on reading from
+disk. Left behind, they bury every future `git status` under an
+untracked `_tmp-*` haystack. The same session that creates a one-shot
+artifact is responsible for deleting it.
+
+## What counts
+
+- Temp helper scripts written to run once: `_tmp-*.ps1`, `_tmp-*.sh`,
+  `_tmp-*.py`, `_tmp-*.js`, etc.
+- Temp JSON / text payloads fed to a single API or CLI call:
+  `_tmp-<ticket>-wi.json`, `_tmp-<ticket>-desc.txt`,
+  `_tmp-<ticket>-ac.txt`.
+- Extract or parse scripts written to pull one value out of an API
+  response and then never used again.
+- PR-body markdown drafts written to disk only because a CLI wants a
+  file (`_tmp-*-pr-body.md`, `PR_BODY.md` used only as `--body-file`).
+
+## What does not count
+
+Never auto-delete these -- they need review, not silent removal:
+
+- Real project source, migrations, or tests.
+- Scripts under a documented, git-tracked `scripts/` folder that has a
+  README explaining what stays.
+- Anything already tracked by git. If a real file has drifted, discuss
+  it, do not silently `rm`.
+
+## Naming and layout
+
+Prefix single-use artifacts with `_tmp-` (or match the repo's existing
+scratch prefix if it already has one). When a task will produce more
+than a couple of files, prefer a per-task subfolder such as
+`scripts/_scratch/<task>/` and delete the whole subfolder at the end
+of the task.
+
+## Delete when done
+
+When the task the artifact was written for ships -- PR merged, work
+item closed, question answered -- the same session removes the
+artifact. Do not leave `_tmp-*` files behind for the next session to
+puzzle over.
+
+## Session-end sweep
+
+Before ending a session, check for untracked `_tmp-*` files the current
+session created and delete them. Do not touch `_tmp-*` files another
+running session might still be using: if you did not create it and you
+are not sure, leave it alone and mention it in your final summary.
+
+## Never
+
+- Delete anything that looks like a secret: `.env*`, `.pat*`, `*.key`,
+  `*.pem`, VAPID / JWT / token blobs. If a secret leaked to disk, tell
+  the user; do not silently `rm`.
+- Run `git clean -fd` (or equivalent broad sweeps) in a shared
+  workspace without explicit user approval.
+- Delete files under `.git/`, `node_modules/`, `venv/`, `.next/`, or
+  other tool-managed directories.
+
+## Reporting
+
+List any `_tmp-*` cruft you leave behind, with a reason, in your final
+summary. Silent orphans defeat the whole point.

--- a/cursor-team-kit/rules/worktree-cleanup.mdc
+++ b/cursor-team-kit/rules/worktree-cleanup.mdc
@@ -1,0 +1,68 @@
+---
+description: Clean up git worktrees when their branch merges so parallel-work siblings do not accumulate
+alwaysApply: true
+---
+
+# Worktree cleanup
+
+Applies to any repo where an agent uses `git worktree` to run parallel
+branch work in sibling directories. The same session that adds a
+worktree is responsible for removing it. Pairs with (does not repeat)
+one-writer-per-branch and subagent-isolation guidance covered by rules
+like `parallel-agent-write-discipline`.
+
+## Create
+
+Use short-lived sibling worktrees off the integration branch, and name
+them so it is obvious what work they hold:
+
+```bash
+git -C <repo> worktree add ../<repo>-wt-<task> \
+  -b feature/<task-or-ticket> origin/<integration-branch>
+```
+
+Reach for a worktree when: another session owns the current branch, the
+tree is dirty with edits you did not author, or a subagent needs write
+access without touching the shared checkout.
+
+## Commit before removing
+
+Never `git worktree remove` a dirty tree. Either land the work (its PR
+merges, or push the WIP branch) or get explicit user OK to discard.
+If a session ends mid-flight, commit WIP with a clear message on the
+feature branch first -- uncommitted work in a removed worktree is gone.
+
+## Remove when done
+
+After the worktree's PR merges (or the branch is abandoned), the same
+session that created it must, from the main checkout:
+
+1. `git worktree remove <path>`
+2. `git worktree prune`
+3. `git branch -d feature/<...>` once fully merged. Do not use `-D`
+   without a merge-into-integration proof and a note explaining it.
+
+Never delete long-lived branches: `main`, `master`, `staging`,
+`develop`, or any equivalent release line.
+
+## Report leftovers
+
+An agent's final response must list any worktree it created and either
+state that it has been removed or explain why it stayed (for example,
+`unmerged WIP at <sha> on branch <name>`). Silent orphans defeat the
+whole point.
+
+## Optional housekeeping pass
+
+At session end, an agent may `git worktree list` and remove siblings
+whose branches are already merged to the integration branch upstream,
+but only when the worktree is clean, `git status` shows no changes it
+did not author, and no other running agent owns it. When in doubt,
+leave it.
+
+## Never touch
+
+- Another running agent's worktree.
+- The main repo checkout the shared session is working out of.
+- Unrelated sibling project folders that happen to live next to the
+  repo's worktree siblings.


### PR DESCRIPTION
## What

Adds two closely related "session hygiene" rules to `cursor-team-kit/rules/` and lists them in the team-kit README:

- `worktree-cleanup.mdc` -- the session that adds a `git worktree` is responsible for removing it when the branch merges (or the work is abandoned), so sibling `<repo>-wt-*` directories do not accumulate.
- `one-shot-script-cleanup.mdc` -- the session that writes a `_tmp-*` helper script or temp payload (JSON fed to a single API call, PR-body drafts written only for `--body-file`, extract/parse one-liners, etc.) is responsible for deleting it when the underlying task ships.

## Why

In agent-heavy workflows both classes of artifact pile up fast:

- Long-running Cursor/ADO/PR loops spin up one worktree per ticket or subagent. If nobody sweeps after merge, the parent directory ends up with dozens of `<repo>-wt-*` siblings and it becomes hard to tell what work is actually live.
- The same loops leave behind `_tmp-*.ps1`, `_tmp-<ticket>-wi.json`, `_tmp-*-pr-body.md`, and similar one-shot scaffolding. Every subsequent `git status` gets buried under untracked scratch.

Both rules pair with (and cross-reference) the existing parallel-agent write-discipline guidance in this ecosystem instead of duplicating it. They only add the "clean up after yourself" half, which was implicit but not written down.

## Guardrails

Both rules explicitly refuse to sweep silently:

- Never touch another running agent's worktree; never delete the main checkout; never delete long-lived branches (`main` / `master` / `staging` / `develop`).
- Never auto-delete anything that looks like a secret (`.env*`, `*.key`, `*.pem`, VAPID / JWT / token blobs) -- report to the user instead.
- Never `git clean -fd` a shared workspace without explicit approval, and never touch tool-managed dirs (`.git/`, `node_modules/`, `venv/`, `.next/`).
- Report any worktree or `_tmp-*` cruft you leave behind, with a reason, in your final summary.

## Notes

- Rule format matches the existing `no-inline-imports.mdc` / `typescript-exhaustive-switch.mdc` (frontmatter with `description` and `alwaysApply: true`, prose body).
- ASCII only.
- README rows added alongside the existing two rule entries.

No functional / code changes; docs-and-rules only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent guidance only; no application code, data access, or production behavior changes.
> 
> **Overview**
> Adds two **always-on agent rules** to `cursor-team-kit` for session hygiene after parallel agent work, plus README table rows for each.
> 
> **`worktree-cleanup`** makes the session that created a sibling `git worktree` remove it after merge or abandonment (`worktree remove`, `prune`, merged feature branch delete), with guardrails against touching the main checkout, long-lived branches, dirty trees, or another agent’s worktree.
> 
> **`one-shot-script-cleanup`** requires deleting untracked `_tmp-*` helpers and single-use payloads when the task ships, with a session-end sweep, explicit exclusions for tracked source and secrets, and a requirement to report any scratch left behind.
> 
> Neither rule changes runtime code—only documented agent behavior, aligned with existing rule frontmatter (`alwaysApply: true`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c96aca0d18b57905e8107911acccb9a65635ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->