### PR TITLE
Add Apollo.io and ZoomInfo third-party MCP plugins

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -107,6 +107,16 @@
       "name": "github",
       "source": "third_party/github",
       "description": "Connect Cursor to GitHub — repositories, issues, pull requests, code search, and Actions — via GitHub's official remote MCP server."
+    },
+    {
+      "name": "apollo-io",
+      "source": "third_party/apollo-io",
+      "description": "Connect Cursor to Apollo.io — prospect search, contact and company enrichment, lists, sequences, and one-off emails — via Apollo's official remote MCP server."
+    },
+    {
+      "name": "zoominfo",
+      "source": "third_party/zoominfo",
+      "description": "Connect Cursor to ZoomInfo — company and contact search, enrichment, buyer intent signals, scoops, and account research — via ZoomInfo's official remote MCP server."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `google-calendar` | [Google Calendar](third_party/google-calendar/) | Cursor | Productivity | Connect Cursor to Google Calendar via Google's remote MCP server — list calendars, search events, and create or update meetings. |
 | `gong` | [Gong](third_party/gong/) | Cursor | Integrations | Gong MCP integration for revenue intelligence — account summaries, deal insights, and call briefs. |
 | `salesforce` | [Salesforce](third_party/salesforce/) | Cursor | Integrations | Connect Cursor to Salesforce via Salesforce Hosted MCP — query, search, create, update, and traverse records in your org. |
+| `apollo-io` | [Apollo.io](third_party/apollo-io/) | Cursor | Integrations | Connect Cursor to Apollo.io — prospect search, contact and company enrichment, lists, sequences, and one-off emails — via Apollo's official remote MCP server. |
+| `zoominfo` | [ZoomInfo](third_party/zoominfo/) | Cursor | Integrations | Connect Cursor to ZoomInfo — company and contact search, enrichment, buyer intent signals, scoops, and account research — via ZoomInfo's official remote MCP server. |
 
 Author values match each plugin’s `plugin.json` `author.name` (Cursor lists `plugins@cursor.com` in the manifest).
 

--- a/third_party/apollo-io/.cursor-plugin/plugin.json
+++ b/third_party/apollo-io/.cursor-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "apollo-io",
+  "displayName": "Apollo.io",
+  "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Connect Cursor to Apollo.io — prospect search, contact and company enrichment, lists, sequences, and one-off emails — via Apollo's official remote MCP server.",
+  "author": {
+    "name": "Cursor",
+    "email": "plugins@cursor.com"
+  },
+  "homepage": "https://docs.apollo.io/docs/apollo-mcp",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "logo": "assets/logo.svg",
+  "keywords": [
+    "apollo",
+    "apollo-io",
+    "sales",
+    "prospecting",
+    "enrichment",
+    "gtm",
+    "mcp"
+  ],
+  "category": "integrations",
+  "tags": [
+    "apollo",
+    "sales",
+    "mcp",
+    "prospecting"
+  ],
+  "mcpServers": "./mcp.json"
+}

--- a/third_party/apollo-io/CHANGELOG.md
+++ b/third_party/apollo-io/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this plugin will be documented here.
+
+## 1.0.0 — initial release
+
+- Logo: Apollo.io brand mark on the brand yellow tile.
+- Added the `apollo-io` MCP server pointing at `https://mcp.apollo.io/mcp`.

--- a/third_party/apollo-io/LICENSE
+++ b/third_party/apollo-io/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cursor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/apollo-io/README.md
+++ b/third_party/apollo-io/README.md
@@ -1,0 +1,53 @@
+# Apollo.io
+
+Cursor plugin that connects agents to [Apollo.io](https://www.apollo.io) through Apollo's official remote [Model Context Protocol](https://modelcontextprotocol.io/) server.
+
+Search Apollo's contact and company database, enrich records, manage contacts and lists, work with sequences and tasks, and send one-off emails from the signed-in Apollo workspace.
+
+This is Apollo.io the sales intelligence platform — not [Apollo GraphOS](https://www.apollographql.com/docs/apollo-mcp-server), which ships an unrelated self-hosted MCP server for GraphQL APIs.
+
+## Install
+
+1. Open **Cursor Settings → Plugins**.
+2. Search for **Apollo.io**.
+3. Click **Install**, then complete the Apollo sign-in prompt.
+
+Or run `/add-plugin apollo-io` in chat.
+
+## MCP
+
+```json
+{
+  "mcpServers": {
+    "apollo-io": {
+      "type": "http",
+      "url": "https://mcp.apollo.io/mcp"
+    }
+  }
+}
+```
+
+Auth is OAuth 2.0 against Apollo. Cursor prompts for Apollo sign-in when the plugin connects — there is no API key to configure.
+
+## Before you connect
+
+Apollo prohibits AI model training on data accessed through Apollo MCP. Turn model training off in your Cursor privacy settings before connecting.
+
+You also need an active Apollo account with access to the records you want the agent to use, plus available credits for enrichment and other credit-consuming actions.
+
+## Notes
+
+- Tool calls run as the Apollo user who authorizes the connection and cannot exceed that user's permissions.
+- People search returns profile data only; use an enrichment action to retrieve emails and phone numbers. Enrichment consumes credits.
+- Revoke access at any time from Apollo's connected apps settings.
+
+## Docs
+
+- Apollo MCP setup: https://docs.apollo.io/docs/apollo-mcp
+- Enrichment overview: https://knowledge.apollo.io/hc/en-us/articles/33699917233293-Enrichment-Overview
+
+Logo is Apollo.io's brand mark on the brand yellow tile, sized to match the other third-party plugin logos.
+
+## License
+
+MIT

--- a/third_party/apollo-io/assets/logo.svg
+++ b/third_party/apollo-io/assets/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none" viewBox="0 0 192 192">
+  <title>Apollo.io</title>
+  <rect width="192" height="192" rx="40" fill="#FFD44D"/>
+  <path fill="#000" d="M96 30 170 160 132 160 96 96 60 160 22 160Z"/>
+  <path fill="#000" d="M96 106c-9 17-13 28-13 35 0 11 8 19 21 19h20l-12-21H99c-4 0-6-2-6-6 0-5 3-13 9-24z"/>
+  <path fill="#000" d="M116 44h38l-19 32z"/>
+</svg>

--- a/third_party/apollo-io/mcp.json
+++ b/third_party/apollo-io/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "apollo-io": {
+      "type": "http",
+      "url": "https://mcp.apollo.io/mcp"
+    }
+  }
+}

--- a/third_party/zoominfo/.cursor-plugin/plugin.json
+++ b/third_party/zoominfo/.cursor-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "zoominfo",
+  "displayName": "ZoomInfo",
+  "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Connect Cursor to ZoomInfo — company and contact search, enrichment, buyer intent signals, scoops, and account research — via ZoomInfo's official remote MCP server.",
+  "author": {
+    "name": "Cursor",
+    "email": "plugins@cursor.com"
+  },
+  "homepage": "https://docs.zoominfo.com/docs/zi-api-mcp-overview",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "logo": "assets/logo.svg",
+  "keywords": [
+    "zoominfo",
+    "sales",
+    "prospecting",
+    "enrichment",
+    "intent",
+    "gtm",
+    "mcp"
+  ],
+  "category": "integrations",
+  "tags": [
+    "zoominfo",
+    "sales",
+    "mcp",
+    "enrichment"
+  ],
+  "mcpServers": "./mcp.json"
+}

--- a/third_party/zoominfo/CHANGELOG.md
+++ b/third_party/zoominfo/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this plugin will be documented here.
+
+## 1.0.0 — initial release
+
+- Logo: ZoomInfo brand mark on the brand red tile.
+- Added the `zoominfo` MCP server pointing at `https://mcp.zoominfo.com/mcp`.

--- a/third_party/zoominfo/LICENSE
+++ b/third_party/zoominfo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cursor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/zoominfo/README.md
+++ b/third_party/zoominfo/README.md
@@ -1,0 +1,51 @@
+# ZoomInfo
+
+Cursor plugin that connects agents to [ZoomInfo](https://www.zoominfo.com) through ZoomInfo's official remote [Model Context Protocol](https://modelcontextprotocol.io/) server.
+
+Search companies and contacts, enrich records with firmographics and verified contact details, surface buyer intent signals, scoops, and news, and generate account and contact research briefings.
+
+## Install
+
+1. Open **Cursor Settings → Plugins**.
+2. Search for **ZoomInfo**.
+3. Click **Install**, then complete the ZoomInfo sign-in prompt.
+
+Or run `/add-plugin zoominfo` in chat.
+
+## MCP
+
+```json
+{
+  "mcpServers": {
+    "zoominfo": {
+      "type": "http",
+      "url": "https://mcp.zoominfo.com/mcp"
+    }
+  }
+}
+```
+
+Auth is OAuth 2.0 against ZoomInfo, including organization SSO. Cursor prompts for ZoomInfo sign-in when the plugin connects — there is no API key to configure.
+
+## Before you connect
+
+ZoomInfo prohibits AI model training on data accessed through ZoomInfo MCP. Turn model training off in your Cursor privacy settings before connecting.
+
+You also need a ZoomInfo license (GTM.ai self-serve or Enterprise). Your plan's API limits, credits, and feature availability all apply to MCP usage.
+
+## Notes
+
+- Tool calls respect the role-based permissions of the ZoomInfo user who authorizes the connection.
+- Search is free; enrichment and research tools consume bulk data or AI action credits.
+
+## Docs
+
+- ZoomInfo MCP overview: https://docs.zoominfo.com/docs/zi-api-mcp-overview
+- Connect ZoomInfo MCP: https://docs.zoominfo.com/docs/connect-to-zoominfo-mcp
+- Available MCP tools: https://docs.zoominfo.com/docs/available-mcp-tools
+
+Logo is ZoomInfo's brand mark on the brand red tile, sized to match the other third-party plugin logos.
+
+## License
+
+MIT

--- a/third_party/zoominfo/assets/logo.svg
+++ b/third_party/zoominfo/assets/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none" viewBox="0 0 192 192">
+  <title>ZoomInfo</title>
+  <rect width="192" height="192" rx="40" fill="#F52A22"/>
+  <path stroke="#fff" stroke-width="22" d="M55 139 130 64"/>
+  <g fill="#fff">
+    <path d="M46 44h68v22H46z"/>
+    <path d="M46 44h22v44H46z"/>
+    <path d="M78 128h68v22H78z"/>
+    <path d="M124 106h22v44h-22z"/>
+    <path d="M114 42h36v36z"/>
+  </g>
+</svg>

--- a/third_party/zoominfo/mcp.json
+++ b/third_party/zoominfo/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "zoominfo": {
+      "type": "http",
+      "url": "https://mcp.zoominfo.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `third_party/apollo-io` and `third_party/zoominfo`, following the same shape as the existing Gmail and Google Workspace plugins.

Both vendors ship official first-party remote MCP servers, so both are the simplest possible plugin shape — a URL-only `mcp.json` with no `variables` block:

| Vendor | Endpoint | Transport / auth | API key |
|:---|:---|:---|:---|
| Apollo.io | `https://mcp.apollo.io/mcp` | Streamable HTTP + OAuth 2.0 | none |
| ZoomInfo | `https://mcp.zoominfo.com/mcp` | Streamable HTTP + OAuth 2.0 | none |

Apollo's server covers prospecting, enrichment, contacts, lists, sequences, tasks, and one-off emails. ZoomInfo's covers company and contact search and enrichment plus buyer intent signals, scoops, news, and account research.

**Each plugin adds** `.cursor-plugin/plugin.json`, `mcp.json`, `README.md`, `CHANGELOG.md`, `LICENSE`, and a 192×192 `assets/logo.svg`, plus entries in `.cursor-plugin/marketplace.json` and the root README table.

**Two things worth a look in review:**

- The Apollo plugin is named `apollo-io`, not `apollo`. In a marketplace full of dev tools, "Apollo" reads as Apollo GraphQL, which ships a completely unrelated self-hosted MCP server for GraphQL APIs. The README says so explicitly.
- Both vendors prohibit AI model training on data pulled through MCP, so both READMEs have a "Before you connect" section telling users to turn model training off first.

**Testing:** `npm install --no-save ajv ajv-formats && node scripts/validate-plugins.mjs` — the same check CI runs — prints "All plugins validated successfully". Both logos were rendered at 192px and 48px next to the existing Gmail logo to confirm they read correctly at marketplace and list sizes:

![Apollo.io and ZoomInfo plugin logos rendered next to the existing Gmail logo](https://cursor.com/artifacts/c/art-03197eff-17e6-48eb-920a-2fbbc944e5a0)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://anysphere.slack.com/archives/C0BCZCY0VH8/p1785956888407519?thread_ts=1785956888.407519&cid=C0BCZCY0VH8)

<div><a href="https://cursor.com/agents/bc-8c176b2b-5fbd-544e-8fe0-a71a5589bf0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c176b2b-5fbd-544e-8fe0-a71a5589bf0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

