### PR TITLE
fix(agent-compatibility): quote SKILL.md description containing colons

### DIFF
--- a/agent-compatibility/skills/check-agent-compatibility/SKILL.md
+++ b/agent-compatibility/skills/check-agent-compatibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-agent-compatibility
-description: Run the full repository compatibility pass: scanner score, startup path, validation loop, and docs reliability.
+description: "Run the full repository compatibility pass: scanner score, startup path, validation loop, and docs reliability."
 ---
 
 # Check agent compatibility


### PR DESCRIPTION
## Summary

Fixes a YAML frontmatter parse error in `check-agent-compatibility/SKILL.md`.

The unquoted description contains colons (`pass: scanner score...`), which YAML interprets as nested mappings. This causes `npx skills update` to emit a warning when scanning the repo:

```
⚠ Skipped .../check-agent-compatibility/SKILL.md — YAML parse error: Nested mappings are not allowed in compact mappings
```

Quoting the description resolves the parse error.

## Test plan

- [x] Verified YAML parses with the `yaml` package used by the skills CLI
- [ ] `npx skills update -p -y` no longer warns on this skill after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only YAML fix with no runtime, security, or data-handling impact.
> 
> **Overview**
> Wraps the `check-agent-compatibility` skill frontmatter **`description`** in double quotes so YAML no longer treats colons in the text (e.g. after “pass”) as nested mappings.
> 
> That removes the skills CLI **“Nested mappings are not allowed in compact mappings”** warning when scanning this skill; skill behavior and body content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21cdc5e8bfdcd92fe164c04d9a20286def5e32be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->