### PR TITLE
feat: add KaiCalls productivity plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -79,6 +79,11 @@
       "description": "Connect to Gmail via Google's remote MCP server — search, read, draft, label, and manage email."
     },
     {
+      "name": "kaicalls",
+      "source": "third_party/kaicalls",
+      "description": "Connect to KaiCalls for AI phone agents, call review, and approved calling workflows."
+    },
+    {
       "name": "google-drive",
       "source": "third_party/google-drive",
       "description": "Connect to Google Drive via Google's remote MCP server — search, read, create, share, and manage files."

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `orchestrate` | [Orchestrate](orchestrate/) | Cursor | Developer Tools | Fan large tasks out across parallel cloud agents with planners, workers, verifiers, and structured handoffs. |
 | `pstack` | [pstack](pstack/) | Lauren Tan | Developer Tools | if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. |
 | `gmail` | [Gmail](third_party/gmail/) | Cursor | Productivity | Connect to Gmail via Google's remote MCP server — search, read, draft, label, and manage email. |
+| `kaicalls` | [KaiCalls](third_party/kaicalls/) | KaiCalls | Productivity | Connect to KaiCalls for AI phone agents, call review, and approved calling workflows. |
 | `google-drive` | [Google Drive](third_party/google-drive/) | Cursor | Productivity | Connect to Google Drive via Google's remote MCP server — search, read, create, share, and manage files. |
 | `google-calendar` | [Google Calendar](third_party/google-calendar/) | Cursor | Productivity | Connect to Google Calendar via Google's remote MCP server — list calendars, search events, and create or update meetings. |
 | `gong` | [Gong](third_party/gong/) | Cursor | Integrations | Gong MCP integration for revenue intelligence — account summaries, deal insights, and call briefs. |

--- a/third_party/kaicalls/.cursor-plugin/plugin.json
+++ b/third_party/kaicalls/.cursor-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "kaicalls",
+  "displayName": "KaiCalls",
+  "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Connect to KaiCalls for AI phone agents, call review, and approved calling workflows.",
+  "author": {
+    "name": "KaiCalls",
+    "email": "support@kaicalls.com"
+  },
+  "homepage": "https://www.kaicalls.com/docs/api",
+  "repository": "https://github.com/KaiCalls/kaicalls-plugin",
+  "license": "MIT",
+  "logo": "assets/logo.svg",
+  "keywords": [
+    "kaicalls",
+    "voice-ai",
+    "phone-calls",
+    "mcp",
+    "agents"
+  ],
+  "category": "productivity",
+  "tags": [
+    "voice-ai",
+    "phone-calls",
+    "call-review",
+    "mcp"
+  ],
+  "mcpServers": "./mcp.json"
+}

--- a/third_party/kaicalls/CHANGELOG.md
+++ b/third_party/kaicalls/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial Cursor Marketplace release with the hosted KaiCalls MCP connector.

--- a/third_party/kaicalls/LICENSE
+++ b/third_party/kaicalls/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026 KaiCalls
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third_party/kaicalls/README.md
+++ b/third_party/kaicalls/README.md
@@ -1,0 +1,14 @@
+# KaiCalls
+
+KaiCalls gives AI agents a phone. This Cursor plugin connects to the hosted KaiCalls MCP server for AI phone-agent workflows, recent-call review, transcripts, and approved outbound calls.
+
+## Setup
+
+Install the plugin, then authenticate your KaiCalls account when prompted. Start with a read-only action such as listing agents or recent calls before attempting any write action.
+
+Outbound calls are real external actions. Confirm the business, agent, recipient, phone number, purpose, and expected outcome before placing a call.
+
+- [KaiCalls](https://www.kaicalls.com)
+- [API documentation](https://www.kaicalls.com/docs/api)
+- [Privacy policy](https://www.kaicalls.com/privacy-policy)
+- [Terms of service](https://www.kaicalls.com/terms-of-service)

--- a/third_party/kaicalls/assets/logo.svg
+++ b/third_party/kaicalls/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="KaiCalls">
+  <rect width="512" height="512" rx="96" fill="#161B1F"/>
+  <path d="M128 96h64v128l104-128h80L256 238l128 178h-78L214 286l-22 26v104h-64V96z" fill="#FFFFFF"/>
+  <circle cx="368" cy="128" r="36" fill="#2563EB"/>
+</svg>

--- a/third_party/kaicalls/mcp.json
+++ b/third_party/kaicalls/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "kaicalls": {
+      "type": "http",
+      "url": "https://www.kaicalls.com/api/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the KaiCalls hosted MCP connector
- list KaiCalls under Productivity
- include setup, safety guidance, and marketplace metadata

## Validation
- all JSON manifests parse successfully
- git diff --check passes
- upstream validate-plugins workflow will run on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSON manifest-only changes; no runtime or core repo logic is modified, though the integration enables real outbound calls via the external MCP service.
> 
> **Overview**
> Adds **KaiCalls** as a new third-party **Productivity** plugin that wires Cursor to KaiCalls’ hosted HTTP MCP at `https://www.kaicalls.com/api/mcp`.
> 
> The change introduces `third_party/kaicalls/` with the standard marketplace bundle: `plugin.json` (KaiCalls author, productivity category, MCP pointer), `mcp.json`, README with auth and **outbound-call safety** guidance, changelog, MIT license, and logo. **Marketplace** (`.cursor-plugin/marketplace.json`) and root **README** plugin tables are updated so `kaicalls` is listed alongside other productivity connectors like Gmail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8add53d6ed15fc00aa03759a229eb21b8f24ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->