### PR TITLE
docs: fix dead Cloud Agents API doc link

### DIFF
--- a/cursor-sdk/skills/cursor-sdk/SKILL.md
+++ b/cursor-sdk/skills/cursor-sdk/SKILL.md
@@ -232,7 +232,7 @@ If the user's integration monitors, lists, or visualizes agents — dashboards o
 
 ## What This Skill Doesn't Cover
 
-- The Cloud Agents REST API (`/v1/agents/*`). If the user needs a non-TS client, the REST API is documented separately at <https://cursor.com/docs/cloud-agent/api>; check there for current capabilities before assuming parity with the SDK.
+- The Cloud Agents REST API (`/v1/agents/*`). If the user needs a non-TS client, the REST API is documented separately at <https://cursor.com/docs/cloud-agent>; check there for current capabilities before assuming parity with the SDK.
 - `.cursor/hooks.json` hooks. Cloud agents execute them but the SDK doesn't manage them; see Cursor's Hooks docs.
 - Private workers / self-hosted cloud. Send users to the Private Workers docs.
 - Python / non-TS SDKs. There is no first-party SDK in other languages at time of writing; REST is the portable option.


### PR DESCRIPTION
The Cloud Agents REST API link (`https://cursor.com/docs/cloud-agent/api`) returns 404. This PR updates it to the live Cloud Agents documentation page (`https://cursor.com/docs/cloud-agent`), which covers the REST API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **“What This Skill Doesn't Cover”** bullet in `cursor-sdk/skills/cursor-sdk/SKILL.md` so the Cloud Agents REST API pointer uses `https://cursor.com/docs/cloud-agent` instead of the 404 `.../docs/cloud-agent/api` URL. Wording is unchanged aside from the link target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524f3b55661c85e483f050824f20745611a495cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->