### PR TITLE
Add plugin content audit to validator and run CI gate on all changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Marketplace integrity: new or modified plugins need a human owner's review.
+# CODEOWNERS makes GitHub block merge until someone from this list approves.
+
+.cursor-plugin/marketplace.json    @DevvGwardo
+**/.cursor-plugin/plugin.json      @DevvGwardo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Dependabot keeps the CI toolchain fresh. The repo has no package.json
+# (the validator installs ajv ad-hoc, pinned exact in the workflow), so only
+# GitHub Actions is tracked here.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # needed for the --base advisory scoping
 
       - uses: actions/setup-node@v4
         with:
@@ -22,4 +24,4 @@ jobs:
         run: npm install --no-save --save-exact ajv@8.17.1 ajv-formats@3.0.1
 
       - name: Validate plugin definitions + content audit
-        run: node scripts/validate-plugins.mjs
+        run: node scripts/validate-plugins.mjs --base=${{ github.event.pull_request.base.sha || 'origin/main' }}

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1,11 +1,12 @@
 name: Validate plugins
 
+# Run on every PR and every push to main. Deliberately NOT path-filtered:
+# the content audit in scripts/validate-plugins.mjs must see plugin file
+# changes (commands/skills/agents/rules), which a path filter would skip.
 on:
   pull_request:
-    paths:
-      - ".cursor-plugin/marketplace.json"
-      - "**/plugin.json"
-      - "schemas/**"
+  push:
+    branches: [main]
 
 jobs:
   validate:
@@ -18,7 +19,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm install --no-save ajv ajv-formats
+        run: npm install --no-save --save-exact ajv@8.17.1 ajv-formats@3.0.1
 
-      - name: Validate plugin definitions
+      - name: Validate plugin definitions + content audit
         run: node scripts/validate-plugins.mjs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 
 ## Plugins
 
+Run validation locally with:
+
+```bash
+npm install ajv ajv-formats
+node scripts/validate-plugins.mjs
+```
+
 | `name` | Plugin | Author | Category | `description` (from marketplace) |
 |:-------|:-------|:-------|:---------|:-------------------------------------|
 | `continual-learning` | [Continual Learning](continual-learning/) | Cursor | Developer Tools | Incremental transcript-driven memory updates for AGENTS.md using high-signal bullet points only. |

--- a/create-plugin/README.md
+++ b/create-plugin/README.md
@@ -39,7 +39,12 @@ Meta workflows for creating Cursor plugins that are marketplace-ready.
 
 1. Use `/create-plugin` with a plugin name, purpose, and target component types.
 2. Generate or update `plugin.json`, then add rules/skills/agents/commands as needed.
-3. Run `review-plugin-submission` before publishing or marketplace submission.
+3. Run the repository validator before publishing or marketplace submission:
+
+   ```bash
+   npm install ajv ajv-formats
+   node scripts/validate-plugins.mjs
+   ```
 
 ## License
 

--- a/create-plugin/skills/review-plugin-submission/SKILL.md
+++ b/create-plugin/skills/review-plugin-submission/SKILL.md
@@ -29,6 +29,7 @@ A plugin is implemented and needs a final quality check before submission or rel
 4. Verify repository integration:
    - For marketplace repos, plugin entry exists in `.cursor-plugin/marketplace.json`
    - `source` resolves to plugin directory and names are unique
+   - `node scripts/validate-plugins.mjs` passes after installing `ajv` and `ajv-formats`
 5. Verify documentation quality:
    - `README.md` states purpose, installation, and component coverage
    - optional logo path is valid and repository-hosted

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, existsSync } from "fs";
-import { resolve, dirname } from "path";
+import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { resolve, dirname, relative, extname } from "path";
 import { fileURLToPath } from "url";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
@@ -25,10 +25,16 @@ const validateMarketplace = ajv.compile(marketplaceSchema);
 const validatePlugin = ajv.compile(pluginSchema);
 
 let errors = 0;
+let warnings = 0;
 
 function fail(message) {
   console.error(`ERROR: ${message}`);
   errors++;
+}
+
+function warn(message) {
+  console.error(`WARN: ${message}`);
+  warnings++;
 }
 
 // 1. Validate marketplace.json
@@ -92,10 +98,172 @@ for (const entry of marketplace.plugins ?? []) {
   }
 }
 
-// 3. Report results
+// 3. Content audit — heuristic security scan of plugin payloads.
+//    Structural validation cannot see inside commands/skills/agents/rules.
+//    Critical findings fail the build; advisory findings are printed for review.
+
+const CODE_FILE = /\.(cjs|js|mjs|ts|tsx|sh|bash|zsh|py|go|rb|pl|php|ex|exs)$/;
+const TEXT_FILE = /\.(md|txt|yaml|yml|toml)$/;
+const BAD_BINARY_EXT = /\.(exe|dylib|so|bin|class|jar|pyc|o)$/;
+
+const CONTENT_AUDIT = [
+  {
+    id: "dynamic-exec",
+    label: "dynamic code execution (eval/Function)",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /\beval\s*\(|\bnew\s+Function\s*\(/,
+  },
+  {
+    id: "obfuscated-code",
+    label: "obfuscated/encoded payload (atob/hex/charCode)",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /\batob\s*\(|Buffer\.from\s*\([^)]*"hex"|String\.fromCharCode\s*\(/,
+  },
+  {
+    id: "subprocess",
+    label: "subprocess/exec usage (review)",
+    severity: "advisory",
+    files: CODE_FILE,
+    re: /\bchild_process\b|\bexecSync\s*\(|\bspawnSync\s*\(|\bspawn\s*\(|\bfork\s*\(/,
+  },
+  {
+    id: "exfil",
+    label: "outbound curl/wget in code",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /\bcurl\b|\bwget\b/,
+  },
+  {
+    id: "reverse-obfusc",
+    label: "string-reversal obfuscation",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /\.split\s*\(\s*["']{2}\s*\)\s*\.reverse\s*\(\s*\)\s*\.join\s*\(/,
+  },
+  {
+    id: "reverse-shell",
+    label: "reverse-shell indicators",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /bash\s+-i|(?:\/dev\/tcp\/|nc\s+-e|netcat\s+-e|mkfifo)/,
+  },
+  {
+    id: "ssh-key-read",
+    label: "reads ~/.ssh credentials",
+    severity: "critical",
+    files: CODE_FILE,
+    re: /(?:~|\$HOME|\/Users\/[\w.-]+)\/\.ssh|\b\.ssh\//,
+  },
+  {
+    id: "ssh-key-read-md",
+    label: "references ~/.ssh credentials (review)",
+    severity: "advisory",
+    files: TEXT_FILE,
+    re: /(?:~|\$HOME|\/Users\/[\w.-]+)\/\.ssh|\b\.ssh\//,
+  },
+  {
+    id: "prompt-injection",
+    label: "prompt-injection / instruction-override language",
+    severity: "critical",
+    files: TEXT_FILE,
+    re: /ignore\s+(?:all\s+)?(?:previous|prior|earlier)\s+(?:instructions|rules|guardrails|safety|system)|disregard\s+(?:previous|prior)|override\s+(?:all\s+)?(?:your\s+)?(?:instructions|rules|guardrails|safety)/i,
+  },
+  {
+    id: "secret-env",
+    label: "reads secrets from environment (review)",
+    severity: "advisory",
+    files: CODE_FILE,
+    re: /process\.env\.[A-Z_0-9]*(TOKEN|SECRET|KEY|PASSWORD)|AWS_SECRET|GITHUB_TOKEN|OPENAI_API_KEY|ANTHROPIC_API_KEY/,
+  },
+];
+
+function walkFiles(dir, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = resolve(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      if (["node_modules", ".git", ".cursor-plugin"].includes(entry)) continue;
+      walkFiles(full, out);
+    } else {
+      out.push(full);
+    }
+  }
+}
+
+function auditContent(filePath) {
+  const rel = relative(root, filePath);
+  const ext = extname(filePath).toLowerCase();
+
+  if (BAD_BINARY_EXT.test(ext)) {
+    fail(`content audit [binary executable extension]: ${rel}`);
+    return;
+  }
+
+  let buf;
+  try {
+    buf = readFileSync(filePath);
+  } catch {
+    return;
+  }
+
+  const magic = buf.subarray(0, 4);
+  const isELF = magic.length === 4 && magic[0] === 0x7f && magic[1] === 0x45 && magic[2] === 0x4c && magic[3] === 0x46;
+  const isPE = magic.length >= 2 && magic[0] === 0x4d && magic[1] === 0x5a;
+  if (isELF || isPE) {
+    fail(`content audit [binary executable blob]: ${rel}`);
+    return;
+  }
+
+  if (buf.length > 2 * 1024 * 1024) return; // too large to text-scan
+
+  if (!CODE_FILE.test(ext) && !TEXT_FILE.test(ext)) return;
+
+  const lines = buf.toString("utf8").split("\n");
+  for (const rule of CONTENT_AUDIT) {
+    if (!rule.files.test(ext)) continue;
+    const cap = rule.severity === "critical" ? 3 : 1; // advisory: one heads-up per file
+    let hits = 0;
+    for (let i = 0; i < lines.length && hits < cap; i++) {
+      if (rule.re.test(lines[i])) {
+        hits++;
+        const msg = `content audit [${rule.label}]: ${rel}:${i + 1}`;
+        if (rule.severity === "critical") fail(msg);
+        else warn(msg);
+      }
+    }
+  }
+}
+
+for (const entry of marketplace.plugins ?? []) {
+  const pluginDir = resolve(root, entry.source);
+  if (!existsSync(pluginDir)) continue;
+  const files = [];
+  walkFiles(pluginDir, files);
+  for (const file of files) auditContent(file);
+}
+
+// 4. Report results
 if (errors > 0) {
   console.error(`\nValidation failed with ${errors} error(s).`);
   process.exit(1);
+} else if (warnings > 0) {
+  console.log(
+    `\nAll plugins validated successfully (${warnings} advisory warning(s) — review flagged lines before merging).`
+  );
+  process.exit(0);
 } else {
   console.log("All plugins validated successfully.");
   process.exit(0);

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { execFileSync } from "child_process";
 import { resolve, dirname, relative, extname } from "path";
 import { fileURLToPath } from "url";
 import Ajv from "ajv";
@@ -26,6 +27,11 @@ const validatePlugin = ajv.compile(pluginSchema);
 
 let errors = 0;
 let warnings = 0;
+
+// Optional: scope advisory findings to files changed since <base> (used by CI
+// for PR review — unchanged first-party code shouldn't re-warn on every run).
+const baseFlag = process.argv.find((a) => a.startsWith("--base="));
+const baseSha = baseFlag ? baseFlag.slice("--base=".length) : null;
 
 function fail(message) {
   console.error(`ERROR: ${message}`);
@@ -234,6 +240,9 @@ function auditContent(filePath) {
   const lines = buf.toString("utf8").split("\n");
   for (const rule of CONTENT_AUDIT) {
     if (!rule.files.test(ext)) continue;
+    if (rule.severity === "advisory" && changedFiles && !changedFiles.has(filePath)) {
+      continue; // unchanged first-party code — only fresh findings are actionable
+    }
     const cap = rule.severity === "critical" ? 3 : 1; // advisory: one heads-up per file
     let hits = 0;
     for (let i = 0; i < lines.length && hits < cap; i++) {
@@ -244,6 +253,27 @@ function auditContent(filePath) {
         else warn(msg);
       }
     }
+  }
+}
+
+// Compute the set of files changed since baseSha (when provided) so advisory
+// findings can be scoped to fresh changes. Falls back to auditing everything
+// if git can't resolve the base.
+let changedFiles = null;
+if (baseSha) {
+  try {
+    const out = execFileSync("git", ["diff", "--name-only", baseSha, "HEAD", "--"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    changedFiles = new Set(
+      out
+        .split("\n")
+        .filter(Boolean)
+        .map((p) => resolve(root, p))
+    );
+  } catch {
+    changedFiles = null;
   }
 }
 


### PR DESCRIPTION
## What

Structural schema validation could not see inside command/skill/agent files, so a plugin with an obfuscated exfiltration payload, outbound `curl`, or a prompt-injection skill sailed through the marketplace gate uncaught. This PR hardens the gate in three commits:

1. **Content audit in `scripts/validate-plugins.mjs`** — every marketplace plugin's files are now scanned:
   - **Critical (fails CI):** obfuscated/encoded payloads (`atob`, hex `Buffer` decoding, `String.fromCharCode`), outbound `curl`/`wget` in code, string-reversal obfuscation, reverse-shell indicators, dynamic `eval`/`new Function`, prompt-injection / instruction-override language in skills, `~/.ssh` reads in code, binary executable blobs (extension + ELF/PE magic-byte check).
   - **Advisory (prints for review, doesn't block):** subprocess/exec usage, env-secret reads, `~/.ssh` references in docs.

2. **CI runs everywhere relevant** — the workflow previously only triggered on `marketplace.json` / `plugin.json` / `schemas/**` changes, so content-only plugin changes (added commands/skills) never ran it. It now runs on **every PR and every push to main**, with ajv deps pinned exact, and passes `--base` so PR review shows **only fresh advisory findings** (unchanged first-party code doesn't re-warn on every run).

3. **Dependabot (GitHub Actions) + CODEOWNERS** gating `marketplace.json` / `plugin.json` on a human owner.

## Verification

- Existing plugins: `node scripts/validate-plugins.mjs` → exit 0 (advisories only, all in `orchestrate`'s legit subprocess/env code).
- Attack repro (private demo): a backdoored plugin (obfuscated hex payload + curl exfil + string reversal) and an injected skill with prompt-injection language → **exit 1, 4 critical errors**, each naming the offending file/line.

## Notes

- No `package.json` exists in this repo; the validator installs `ajv`/`ajv-formats` ad-hoc (now pinned exact in CI). Dependabot tracks only the GitHub Actions ecosystem for that reason.
- Advisories are scoped to changed files via `--base=<ref>`; run without the flag for a full sweep.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes marketplace merge gates and security heuristics may false-positive on legitimate plugin code (e.g. subprocess in orchestrate); critical rules block merges on pattern matches.
> 
> **Overview**
> **Hardens marketplace validation** by scanning plugin file contents (commands, skills, agents, rules) for security red flags, not only JSON schema checks.
> 
> `scripts/validate-plugins.mjs` now walks each marketplace plugin tree and runs heuristic rules: **critical** hits (eval, obfuscation, curl/wget, reverse-shell patterns, prompt-injection language, SSH reads, binaries) fail the build; **advisory** hits (subprocess, env secrets, SSH in docs) emit warnings. Optional `--base=<ref>` limits advisories to files changed since that ref so unchanged first-party code does not re-warn every CI run.
> 
> **CI** drops path filters so validation runs on every PR and push to `main`, uses full git history for `--base`, and pins exact `ajv` / `ajv-formats` versions. **CODEOWNERS** requires review for `marketplace.json` and `plugin.json`; **Dependabot** weekly-updates GitHub Actions. README and create-plugin docs point submitters at `node scripts/validate-plugins.mjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd072c5e59348d2f0ab7403bda4630fd2673ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->