### PR TITLE
pstack: record outside-diff CSS-string DTCG skip

### DIFF
--- a/pstack/skills/poteto-mode/references/bugbot-triage.md
+++ b/pstack/skills/poteto-mode/references/bugbot-triage.md
@@ -140,3 +140,11 @@ Append new candidate learnings here during or after babysitting when they look t
   exists for a missing dependency rather than a failed operation.
 - Source: one CLI-rename PR whose fallback existed for a missing binary rather
   than a failed command.
+
+### Outside-diff token-format complaints against catalog CSS strings
+
+- Confidence: candidate
+- Skip when: A review-automation comment asks to convert dimension or shadow tokens from CSS strings (`"0.25rem"`, `"2px 2px 4px rgba(...)"`) to structured DTCG objects, the cited tokens are outside the PR hunk or byte-identical on the base branch, and sibling tokens in the same catalog already use CSS strings for those types.
+- Do not skip when: This PR added a token in a shape no sibling uses, token validation or generation fails on the tip, or the pipeline for this type cannot emit a CSS string.
+- Example signal: "Use structured DTCG values" or "tooltip-radius and tooltip-shadow use CSS strings instead of the required DTCG dimension and shadow objects", posted outside the diff after a merge that only inserted neighboring tokens.
+- Source: one design-token theme-bridge PR. CodeRabbit flagged landed tooltip radius and shadow CSS strings that already existed on the base branch in the same shape as the rest of the catalog.


### PR DESCRIPTION
Babysit on a design-token theme-bridge PR dismissed an outside-diff CodeRabbit finding. The bot asked to convert landed tooltip radius and shadow tokens from CSS strings to structured DTCG objects. Those tokens already existed on the base branch in the same shape as the rest of the catalog.

This adds that pattern as a candidate skip in `pstack/skills/poteto-mode/references/bugbot-triage.md`. Do not skip when the PR introduced a unique token shape, or when validation or generation fails on the tip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 796da11f5b1ae87b775f1f7a51788ffdcbfcac7e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->