### PR TITLE
Remove command from unslop skill description

### DIFF
--- a/pstack/skills/unslop/SKILL.md
+++ b/pstack/skills/unslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unslop
-description: Cut AI tells from any writing. Must always apply.
+description: Cut AI tells from any writing.
 ---
 
 # Unslop


### PR DESCRIPTION
Agents are using unslop simply by looking at the description because it has a command in it "Must always apply".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 48f7749f20c11b49c69b5b18dc8f38892d6eb04c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->