### PR TITLE
fix(pstack): make poteto-mode SKILL.md name schema-conformant

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: Poteto Mode
+name: poteto-mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
 mode: true
 icon: crown
 color: yellow
 reminder: New task? Playbook match or rigor needed -> apply /poteto-mode. Casual turn or user opts out -> don't.
+metadata:
+  cursor-display-name: Poteto Mode
 ---
 
 # Poteto mode


### PR DESCRIPTION
## Summary

`pstack/skills/poteto-mode/SKILL.md` declares `name: Poteto Mode` -- capitals and a space, and it doesn't match its parent folder `poteto-mode`. This violates the documented frontmatter constraint (Agent Skills docs: "Lowercase letters, numbers, and hyphens only. Must match the parent folder name.") and the identical rule in the agentskills.io spec.

It's the only one of pstack's 44 skills that doesn't conform, and it fails to register at all on other spec-compliant harnesses (verified against Kiro, which loads skills from `~/.kiro/skills/` following the same spec -- a conforming copy registers normally, this one doesn't, and fails silently with no surfaced error).

## Fix

Applies the first of the two fixes proposed in #237: set `name: poteto-mode` to match the folder and the documented identifier pattern (`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`), and move the capitalized slash-menu label into `metadata.cursor-display-name` -- the field the frontmatter spec designates for client-specific display extras. This preserves the display behavior PR #149 introduced ("name field is the display label in the slash menu") without needing any Cursor-side product change.

All other frontmatter fields (`disable-model-invocation`, `mode`, `icon`, `color`, `reminder`) are untouched -- out of scope for this fix.

## Testing

- Parsed the patched frontmatter with PyYAML and confirmed `name: poteto-mode` full-matches the documented identifier regex and equals the parent folder name.
- Confirmed `metadata.cursor-display-name: Poteto Mode` round-trips correctly.
- Searched the repo for other references to the literal string `"Poteto Mode"` -- none exist outside this file, so no other call site depends on the old value.

Fixes #237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter-only metadata change on one skill file; no runtime, auth, or data-handling logic.
> 
> **Overview**
> Aligns `poteto-mode` skill frontmatter with the Agent Skills identifier spec so the skill can register on spec-compliant harnesses.
> 
> Sets `name` to `poteto-mode` (matching the folder and `^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`) and moves the slash-menu label **Poteto Mode** into `metadata.cursor-display-name`. Other frontmatter is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78594eb53d7c8737acc49dce4b97765a15640d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->