### PR TITLE
fix: correct poteto-mode skill identifier

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: Poteto Mode
+name: poteto-mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
 mode: true
 icon: crown
 color: yellow
 reminder: New task? Playbook match or rigor needed -> apply /poteto-mode. Casual turn or user opts out -> don't.
+metadata:
+  cursor-display-name: Poteto Mode
 ---
 
 # Poteto mode


### PR DESCRIPTION
## Summary

Fix the `poteto-mode` skill identifier to comply with the documented Agent Skills/Cursor identifier requirements.

- Changed `name: Poteto Mode` to `name: poteto-mode`
- Preserved the human-readable display name as `Poteto Mode`
- `node scripts/validate-plugins.mjs` passes

Fixes #237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter-only identifier fix with no runtime, auth, or data-handling changes.
> 
> **Overview**
> Aligns the `poteto-mode` skill `name` with Agent Skills/Cursor identifier rules by changing it from `Poteto Mode` to `poteto-mode`.
> 
> Keeps the human-readable label as `Poteto Mode` via `metadata.cursor-display-name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9e9321e663660e034c0b69a945c0cfb3e03440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->