### PR TITLE
pstack: fix poteto-mode skill name to satisfy identifier constraint

### DIFF
--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: Poteto Mode
+name: poteto-mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
 mode: true
 icon: crown
 color: yellow
 reminder: New task? Playbook match or rigor needed -> apply /poteto-mode. Casual turn or user opts out -> don't.
+metadata:
+  cursor-display-name: Poteto Mode
 ---
 
 # Poteto mode


### PR DESCRIPTION
## Summary

Fixes #237.

`pstack/skills/poteto-mode/SKILL.md` declares `name: Poteto Mode`, which violates Cursor's own documented Agent Skills frontmatter constraint (name must be lowercase letters/numbers/hyphens only, and must match the parent folder name — `poteto-mode`). It's the only one of pstack's skills that doesn't conform.

This was introduced deliberately in #149 to give the skill a nicer slash-menu label, on the reasoning that routing derives from the folder path so the field is "just" a display label inside Cursor. That holds inside Cursor, but the Agent Skills spec defines `name` as the identifier, not a display label, and other spec-conformant harnesses (verified on Kiro) fail to register the skill at all when it doesn't match — silently, with no error surfaced. It also fails the `skills-ref` conformance validator.

## Fix

Applying suggested fix option 1 from the issue: set `name: poteto-mode` (matches the folder, conformant) and move the human-readable label into `metadata`, which the documented frontmatter table designates for client-specific extras:

```yaml
name: poteto-mode
metadata:
  cursor-display-name: Poteto Mode
```

## Note

Per the issue: `metadata.cursor-display-name` fixes the portability break (the identifier is now spec-conformant everywhere), but I don't know whether Cursor's client currently reads that key to render the slash-menu label — if not, the menu entry may show `poteto-mode` instead of `Poteto Mode` until/unless Cursor adds that lookup (the issue's suggested fix option 2, first-class `displayName` support for skill frontmatter, would need Cursor-side work beyond this PR's scope).

## Testing

- No other file in the repo references this skill's `name` field value, so this is a self-contained, non-breaking change.
- Not in the path set that `.github/workflows/validate-plugins.yml` triggers on (`.cursor-plugin/marketplace.json`, `**/plugin.json`, `schemas/**`), so no CI job runs against this diff; verified the YAML frontmatter parses correctly by hand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter-only identifier fix on one skill file; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Makes the `poteto-mode` skill register on spec-conformant harnesses by setting `name` to `poteto-mode` (matching the folder) instead of the display string `Poteto Mode`.
> 
> The human-readable label moves to `metadata.cursor-display-name`. Skill body is unchanged. Cursor may still show the hyphenated identifier in the slash menu until it honors that metadata key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797d638bb57649da0be4d5742023b93fc60d92f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->