### PR TITLE
orchestrate: redact the whole value in redactBody, not up to the first space

### DIFF
--- a/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
@@ -41,6 +41,28 @@ describe("redactBody", () => {
     expect(redactBody(`\`${sha}\``).reasons).toEqual([]);
   });
 
+  test("redacts the credential after an auth scheme, not just the scheme", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.SECRETPAYLOAD.sig";
+    const result = redactBody(`Authorization: Bearer ${jwt}`);
+
+    expect(result.text).toBe("Authorization=[redacted]");
+    expect(result.text).not.toContain(jwt);
+    expect(result.reasons).toContain("contains sensitive key");
+  });
+
+  test("redacts a quoted value containing spaces", () => {
+    const result = redactBody('export TOKEN="my secret value"');
+
+    expect(result.text).toBe("export TOKEN=[redacted]");
+    expect(result.text).not.toContain("secret value");
+  });
+
+  test("redacts only the offending line", () => {
+    const result = redactBody("password: hunter2\nnext line stays");
+
+    expect(result.text).toBe("password=[redacted]\nnext line stays");
+  });
+
   test("allows concise operational context", () => {
     const result = redactBody("blocked: docker rate-limit on redis:7");
 

--- a/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
@@ -1,7 +1,9 @@
 const MAX_BODY_CHARS = 2_048;
 const SENSITIVE_KEY_RE = /token|secret|password|api[_-]?key|authorization/i;
+// Value runs to end of line: `\S+` stopped at the first space, which left the
+// credential behind in `Authorization: Bearer <jwt>` and in quoted values.
 const SENSITIVE_ASSIGNMENT_RE =
-  /\b(token|secret|password|api[_-]?key|authorization)\b\s*[:=]\s*\S+/gi;
+  /\b(token|secret|password|api[_-]?key|authorization)\b\s*[:=]\s*\S.*/gi;
 const PATH_PATTERNS = [
   { re: /^\/workspace\/\S*/gm, reason: "contains /workspace path" },
   { re: /^\/Users\/\S*/gm, reason: "contains /Users path" },


### PR DESCRIPTION
## What

`redactBody`'s sensitive-assignment pattern matched `\S+` after the `:`/`=`, so it stopped at the first space:

```
Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.SECRETPAYLOAD.sig
  ->  "Authorization=[redacted] eyJhbGciOiJIUzI1NiJ9.SECRETPAYLOAD.sig"   reasons: ["contains sensitive key"]

export TOKEN="my secret value"
  ->  "export TOKEN=[redacted] secret value\""                            reasons: ["contains sensitive key"]
```

In both cases the token is the part after the space, so the function redacted the scheme (`Bearer`) or the first word and left the credential in the returned `text` — while `reasons` reported a successful redaction.

Matching to end of line instead makes the returned text actually redacted:

```
  ->  "Authorization=[redacted]"
  ->  "export TOKEN=[redacted]"
```

## Why

`Authorization: Bearer <token>` is the usual shape an auth header takes in the error output and logs that get pasted into a comment body, and it is the one shape the old pattern handled worst.

To be precise about impact: today's only caller is `requireSafeCommentBody` in `cli/comments.ts`, which throws whenever `reasons` is non-empty, so nothing currently reaches Slack with a leaked credential. The defect is in `redactBody`'s own contract — it returns a `text` that is presented as redacted and isn't — so any caller that uses `result.text`, which is the obvious reading of the return shape, leaks. The branch also had no test coverage at all: the existing suite covered paths, SHAs, log dumps and size, but never the sensitive-key path.

`.` does not match newlines, so redaction still stops at the end of the offending line; there's a test for that.

## How

One character class in `SENSITIVE_ASSIGNMENT_RE` (`\S+` → `\S.*`), plus three tests. The two credential tests fail on `main`:

```
Expected: "Authorization=[redacted]"
Received: "Authorization=[redacted] eyJhbGciOiJIUzI1NiJ9.SECRETPAYLOAD.sig"

Expected: "export TOKEN=[redacted]"
Received: "export TOKEN=[redacted] secret value""
```

Full suite: 212 pass / 0 fail across 28 files. `tsc --noEmit` and `biome check` clean.

I left `orchestrate/.cursor-plugin/plugin.json` at `1.1.0` since version bumps look like a deliberate maintainer step in this repo — happy to bump it if you'd like it in the same PR.

---

*Disclosure: written with AI assistance; the analysis, fix and tests were verified locally.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret-redaction logic used for comment bodies. The change is a small regex plus tests; current callers reject on reasons so this mainly closes a leak if `result.text` is used.
> 
> **Overview**
> Fixes `redactBody` so sensitive assignments redact through end of line instead of stopping at the first space.
> 
> The old `\S+` match left JWTs after `Authorization: Bearer` and quoted secrets in `result.text` while still reporting `"contains sensitive key"`. Matching `\S.*` now yields `KEY=[redacted]` for those shapes, still line-scoped. Adds tests for Bearer tokens, quoted values, and neighboring lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e213ca4ecf9e8a2ec214683c5d54cb20fa0d31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->