### PR TITLE
ci: validate referenced component paths in plugin manifests

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -6,6 +6,7 @@ on:
       - ".cursor-plugin/marketplace.json"
       - "**/plugin.json"
       - "schemas/**"
+      - "scripts/**"
 
 jobs:
   validate:

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -48,8 +48,23 @@ function isAbsoluteUrl(value) {
 // Cursor. Glob patterns are checked against their static directory prefix so
 // a typo in the base directory is still caught.
 function checkReferencedPath(pluginName, pluginDir, field, declared) {
-  if (typeof declared !== "string" || declared.trim().length === 0) return;
-  if (isAbsoluteUrl(declared)) return;
+  if (typeof declared !== "string") return;
+
+  if (declared.trim().length === 0) {
+    fail(`Plugin "${pluginName}": ${field} path must not be empty`);
+    return;
+  }
+
+  // The schema allows `logo` to be an absolute URL; every other component
+  // field is a local path, so a remote-looking value there is a mistake the
+  // existence check would otherwise silently skip.
+  if (isAbsoluteUrl(declared)) {
+    if (field === "logo") return;
+    fail(
+      `Plugin "${pluginName}": ${field} path "${declared}" must be a local path relative to the plugin directory`
+    );
+    return;
+  }
 
   const normalized = declared.replace(/^\.\//, "").replace(/\/+$/, "");
   if (!normalized || normalized.startsWith("/")) {

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, existsSync } from "fs";
-import { resolve, dirname } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
@@ -29,6 +29,67 @@ let errors = 0;
 function fail(message) {
   console.error(`ERROR: ${message}`);
   errors++;
+}
+
+// Fields whose declared value is a path (or glob) relative to the plugin
+// directory. `hooks`/`mcpServers` may also be inline objects and `logo` may
+// be an absolute URL per the schema — those are skipped by the caller.
+const COMPONENT_PATH_FIELDS = ["skills", "agents", "commands", "rules"];
+const COMPONENT_SINGLE_PATH_FIELDS = ["hooks", "mcpServers", "logo"];
+
+function isAbsoluteUrl(value) {
+  return /^(?:https?:|data:)/i.test(value);
+}
+
+// Verify that a path declared in plugin.json resolves to an existing file or
+// directory under the plugin directory. Schema validation only checks the
+// shape of plugin.json, so a typo'd component path (e.g. "skils/" or a
+// renamed hook file) currently passes CI and silently fails to load in
+// Cursor. Glob patterns are checked against their static directory prefix so
+// a typo in the base directory is still caught.
+function checkReferencedPath(pluginName, pluginDir, field, declared) {
+  if (typeof declared !== "string" || declared.trim().length === 0) return;
+  if (isAbsoluteUrl(declared)) return;
+
+  const normalized = declared.replace(/^\.\//, "").replace(/\/+$/, "");
+  if (!normalized || normalized.startsWith("/")) {
+    fail(
+      `Plugin "${pluginName}": ${field} path "${declared}" must be relative to the plugin directory`
+    );
+    return;
+  }
+  if (normalized.split(/[\\/]/).includes("..")) {
+    fail(
+      `Plugin "${pluginName}": ${field} path "${declared}" must not escape the plugin directory`
+    );
+    return;
+  }
+
+  const globIndex = normalized.search(/[*?[\]]/);
+  const staticPart =
+    globIndex >= 0
+      ? normalized.slice(0, globIndex).replace(/\/+$/, "")
+      : normalized;
+  const fullPath = resolve(pluginDir, staticPart);
+  if (!existsSync(fullPath)) {
+    fail(
+      `Plugin "${pluginName}": ${field} path "${declared}" does not exist (resolved to ${relative(root, fullPath)})`
+    );
+  }
+}
+
+// Check every component path declared by a plugin.json. Strings that may also
+// be inline objects (hooks/mcpServers) are skipped, not treated as paths.
+function checkPluginComponentPaths(pluginName, pluginDir, pluginJson) {
+  for (const field of [...COMPONENT_PATH_FIELDS, ...COMPONENT_SINGLE_PATH_FIELDS]) {
+    const value = pluginJson[field];
+    if (value === undefined) continue;
+    const patterns = Array.isArray(value) ? value : [value];
+    for (const pattern of patterns) {
+      if (typeof pattern !== "string") continue;
+      checkReferencedPath(pluginName, pluginDir, field, pattern);
+    }
+  }
 }
 
 // 1. Validate marketplace.json
@@ -90,6 +151,11 @@ for (const entry of marketplace.plugins ?? []) {
       `Plugin "${entry.name}": marketplace name does not match plugin.json name "${pluginJson.name}"`
     );
   }
+
+  // Check that component paths declared in plugin.json exist under the plugin
+  // directory. A typo'd skill/hook path passes schema validation but silently
+  // fails to load in Cursor, so catch it at review time.
+  checkPluginComponentPaths(entry.name, pluginDir, pluginJson);
 }
 
 // 3. Report results


### PR DESCRIPTION
## What

`scripts/validate-plugins.mjs` only checks plugin.json against the JSON schema and that the marketplace name matches the manifest name. A typo'd component path — e.g. `"skills": "./skils/"` or a renamed `hooks/hooks.json` — passes schema validation and CI but silently fails to load in Cursor. This PR adds an existence check for every path declared in `plugin.json`:

- `skills`, `agents`, `commands`, `rules`, `hooks`, `mcpServers`, `logo`
- Paths are resolved relative to the plugin directory (`./` prefix stripped)
- Inline `hooks`/`mcpServers` objects and absolute-URL `logo` values are skipped, matching the schema's allowed shapes
- Glob patterns (e.g. `skills/*`) are validated against their static directory prefix so a typo in the base directory is still caught
- Paths that escape the plugin directory (`..`) or are absolute are rejected

Also adds `scripts/**` to the `validate-plugins.yml` `paths` filter, so a PR that only changes the validator itself now triggers the job that runs it (previously a broken validator could merge without CI ever executing it).

## Why

All 32 current marketplace plugins pass the new check (verified locally). The check only guards future PRs — which is the point of a merge gate: a contributor adding a new plugin or tweaking an existing manifest can't merge a path that Cursor will silently ignore.

## Verification

- `node scripts/validate-plugins.mjs` exits 0 on the current repo.
- Intentionally breaking a path (`skills` -> `./skils/`) produces a clear error and non-zero exit: `ERROR: Plugin "teaching": skills path "./skils/" does not exist (resolved to teaching\skils)`.
- Edge cases exercised: inline `hooks` object (skipped), absolute-URL `logo` (skipped), glob with valid/invalid prefix, and `../` path traversal (rejected).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only validation of plugin manifests; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Plugin CI now fails when a `plugin.json` points at component files that do not exist, instead of only schema-checking the manifest (typos like `skils/` previously merged and then silently failed to load in Cursor).
> 
> After schema and name checks, the validator resolves `skills`, `agents`, `commands`, `rules`, `hooks`, `mcpServers`, and `logo` relative to the plugin directory. Inline objects and URL logos are skipped; globs are checked on their static prefix; empty, absolute, and `..` paths are rejected.
> 
> The validate-plugins workflow also runs on `scripts/**` so validator-only PRs are actually exercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ac5375de7094189953a995c808ba0c23acf38ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->