### PR TITLE
docs: clarify plugin install vs disable vs uninstall lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ plugins/
 └── ...
 ```
 
+## Plugin lifecycle
+
+Install, disable, and uninstall are distinct actions, and a plugin's cached artifacts are not evidence that it is enabled. See [docs/plugin-lifecycle.md](docs/plugin-lifecycle.md).
+
 ## License
 
 MIT

--- a/docs/plugin-lifecycle.md
+++ b/docs/plugin-lifecycle.md
@@ -1,0 +1,46 @@
+# Plugin lifecycle
+
+Install, disable, and uninstall are three different things. Mixing them up is the most common source of "why is this plugin still showing up?" confusion, so this page states what each one means and how to check a plugin's current state.
+
+## Lifecycle
+
+| Action | What it means |
+|:-------|:--------------|
+| **Install** | The plugin's artifacts — its skills, rules, agents, commands, and MCP server definitions — become available to Cursor. Install from **Customize** in the sidebar, or run `/add-plugin <name>` in chat. |
+| **Disable** | The plugin stays installed, but Cursor's plugin-management state marks it as not active. Its components should not be used by the agent while it is disabled. |
+| **Uninstall / remove** | The plugin is removed rather than merely turned off. Getting it back means installing it again. |
+
+Disable is a state change, not a removal. Uninstall is a removal, not a state change.
+
+## The plugin cache is not enable state
+
+Cursor keeps downloaded plugin artifacts under a cache directory inside `~/.cursor/plugins/`. That cache answers "what has been downloaded", not "what is currently enabled".
+
+So:
+
+- A plugin's files being present in the cache does **not** mean the plugin is enabled.
+- Deleting or moving cache directories is **not** a supported way to disable a plugin. Cursor manages that directory itself, and hand-editing it does not change the plugin's enabled state.
+
+Use the plugin-management UI to disable a plugin, not the filesystem.
+
+## Checking whether a plugin is enabled
+
+The supported answer is Cursor's own plugin management:
+
+- **Customize** in the sidebar, or **Cursor Settings → Plugins**, shows installed plugins and lets you toggle them.
+- In the Cursor CLI, `/plugin` manages plugins and marketplaces.
+
+Anything else — cache directories, internal state files — is an implementation detail. Those details can change between Cursor versions and are not a reliable basis for normal plugin management, so treat the UI as the source of truth.
+
+## Troubleshooting
+
+**A plugin's components still appear after you disable it.** Start a new agent session. A session that was already running may have loaded the plugin's components before you changed anything, so a fresh session is the simplest way to confirm what the current state actually is.
+
+**A plugin you installed does not show up.** Check that it is enabled in **Customize** or **Cursor Settings → Plugins**, then start a new session and try again.
+
+**A local plugin under development is not loading.** Local plugins live in `~/.cursor/plugins/local/<plugin-name>/`. Confirm the directory contains a valid `.cursor-plugin/plugin.json` — see [Repository structure](../README.md#repository-structure) for the expected layout, and the [create-plugin](../create-plugin/) plugin for scaffolding and pre-submission checks.
+
+## Related docs
+
+- [Cursor plugins documentation](https://cursor.com/docs/plugins)
+- [Cursor CLI slash commands](https://cursor.com/docs/cli/reference/slash-commands)


### PR DESCRIPTION
Addresses #136

## What

Adds `docs/plugin-lifecycle.md` and a short pointer to it from the README.

The repo had no documentation explaining how install, disable, and uninstall differ, which can make cached plugin artifacts easy to mistake for enabled-state evidence.

## Contents

- A lifecycle table distinguishing install, disable, and uninstall.
- An explicit note that cached plugin artifacts are not authoritative evidence that a plugin is currently enabled.
- Guidance to use Cursor's supported plugin-management surfaces, including **Customize** / **Cursor Settings → Plugins**, as the source of truth for enabled state.
- A short troubleshooting section recommending a new agent session after changing plugin state.

## Scope

Deliberately conservative:

- No undocumented internal state-storage details such as `state.vscdb` keys.
- No hardcoded cache marketplace subdirectory names.
- No undocumented CLI subcommands.
- No claims about specific disk-deletion behavior on disable or uninstall.
- Product UX issues raised in #136 are not changed here.

This is filed as `Addresses #136` rather than `Closes #136` because some parts of the issue concern product behavior rather than repository documentation.

## Validation

```text
npm install --no-save ajv ajv-formats
node scripts/validate-plugins.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, security, or runtime impact.
> 
> **Overview**
> Adds documentation that **install**, **disable**, and **uninstall** are separate actions, and that files in the plugin cache are not proof a plugin is enabled.
> 
> A new `docs/plugin-lifecycle.md` explains each action, points people at Cursor’s plugin UI/CLI as the source of truth, and covers common issues (stale sessions, missing plugins, local plugin layout). The README now links to that page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626a91785e86737d8a7d00be54e79872ab181242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->