### PR TITLE
orchestrate: redact quoted JSON keys and whole values in redactBody

### DIFF
--- a/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
@@ -68,6 +68,18 @@ describe("redactBody", () => {
     );
   });
 
+  test("does not truncate a quoted value at an inner apostrophe", () => {
+    // Bugbot round 2: the first fix merged `"` and `'` into one character
+    // class, so a double-quoted value containing an apostrophe ended at it and
+    // leaked the secret tail. The opening quote must decide the closing quote.
+    expect(
+      redactBody(`{"password": "it's a secret123"}`).text
+    ).toBe("{password=[redacted]}");
+    expect(redactBody(`{"token": "don't-panic"}`).text).toBe(
+      "{token=[redacted]}"
+    );
+  });
+
   test("allows concise operational context", () => {
     const result = redactBody("blocked: docker rate-limit on redis:7");
 

--- a/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
@@ -41,6 +41,22 @@ describe("redactBody", () => {
     expect(redactBody(`\`${sha}\``).reasons).toEqual([]);
   });
 
+  test("redacts quoted JSON keys and values containing spaces", () => {
+    // The old pattern used \b around the key, so a quote-adjacent key like
+    // "api_key" in a pasted JSON body never matched and the secret went out
+    // unredacted. It also stopped the value at the first space, leaking
+    // `Bearer <jwt>` tails.
+    expect(
+      redactBody('{"Authorization": "Bearer eyJhbG.sig"}').text
+    ).toContain("Authorization=[redacted]");
+    expect(
+      redactBody('{"api_key": "sk-123", "name": "x"}').text
+    ).not.toContain("sk-123");
+    expect(redactBody('api_key = "super secret value"').text).toBe(
+      'api_key=[redacted]'
+    );
+  });
+
   test("allows concise operational context", () => {
     const result = redactBody("blocked: docker rate-limit on redis:7");
 

--- a/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
+++ b/orchestrate/skills/orchestrate/scripts/__tests__/redact-body.test.ts
@@ -57,6 +57,17 @@ describe("redactBody", () => {
     );
   });
 
+  test("redacts unquoted values up to a separator, consuming it", () => {
+    // Cursor Bugbot flagged the first cut: the value pattern stopped at
+    // `,`/`;`/`}` without consuming them, so an unquoted assignment failed to
+    // match entirely and the raw secret passed through.
+    const result = redactBody("password: hunter2, keep");
+    expect(result.text).toBe("password=[redacted] keep");
+    expect(redactBody("token = abc123; next=1").text).toBe(
+      "token=[redacted] next=1"
+    );
+  });
+
   test("allows concise operational context", () => {
     const result = redactBody("blocked: docker rate-limit on redis:7");
 

--- a/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
@@ -2,11 +2,14 @@ const MAX_BODY_CHARS = 2_048;
 const SENSITIVE_KEY_RE = /token|secret|password|api[_-]?key|authorization/i;
 const SENSITIVE_ASSIGNMENT_RE =
   /"?((?:[\w.-]+\/)?(?:token|secret|password|api[_-]?key|authorization)[\w.-]*)"?\s*[:=]\s*/gi;
-// The value is matched lazily up to a separator that ends the assignment:
-// end of line, an unquoted-word boundary followed by `,`/`;`/`}` (JSON-ish
-// contexts), or a closing quote. Everything between belongs to the secret and
-// gets redacted whole — including values with spaces (`Bearer eyJ... sig`).
-const SENSITIVE_VALUE_RE = /[^,;}\n"']*(?:["'][^"']*["']?|[,;}]?)/;
+// The value is matched up to a real assignment boundary and redacted whole:
+//  - a double-quoted value runs to its closing `"` (escaped quotes allowed), so a
+//    quoted value containing an apostrophe is not truncated at it;
+//  - a single-quoted value runs to its closing `'` (escaped quotes allowed);
+//  - an unquoted value runs to `,`/`;`/`}`/end-of-line, consuming one optional
+//    terminator so the assignment ends at a real boundary (Bugbot round 1).
+const SENSITIVE_VALUE_RE =
+  /(?:"(?:\\.|[^"\\])*"?|'(?:\\.|[^'\\])*'?|[^,;}\n]*[,;}]?)/;
 const PATH_PATTERNS = [
   { re: /^\/workspace\/\S*/gm, reason: "contains /workspace path" },
   { re: /^\/Users\/\S*/gm, reason: "contains /Users path" },

--- a/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
@@ -1,7 +1,12 @@
 const MAX_BODY_CHARS = 2_048;
 const SENSITIVE_KEY_RE = /token|secret|password|api[_-]?key|authorization/i;
 const SENSITIVE_ASSIGNMENT_RE =
-  /\b(token|secret|password|api[_-]?key|authorization)\b\s*[:=]\s*\S+/gi;
+  /"?((?:[\w.-]+\/)?(?:token|secret|password|api[_-]?key|authorization)[\w.-]*)"?\s*[:=]\s*/gi;
+// The value is matched lazily up to a separator that ends the assignment:
+// end of line, an unquoted-word boundary followed by `,`/`;`/`}` (JSON-ish
+// contexts), or a closing quote. Everything between belongs to the secret and
+// gets redacted whole — including values with spaces (`Bearer eyJ... sig`).
+const SENSITIVE_VALUE_RE = /[^,;}\n"']*(?:"[^"]*"?|'[^']*'?|$|\s(?=[\w"'])|$)/;
 const PATH_PATTERNS = [
   { re: /^\/workspace\/\S*/gm, reason: "contains /workspace path" },
   { re: /^\/Users\/\S*/gm, reason: "contains /Users path" },
@@ -33,14 +38,16 @@ function redactSensitiveAssignments(
   text: string,
   reasons: Set<string>
 ): string {
-  return text.replace(SENSITIVE_ASSIGNMENT_RE, match => {
-    const [key] = match.split(/\s*[:=]\s*/, 1);
-    if (SENSITIVE_KEY_RE.test(key ?? "")) {
-      reasons.add("contains sensitive key");
-      return `${key}=[redacted]`;
+  return text.replace(
+    new RegExp(SENSITIVE_ASSIGNMENT_RE.source + SENSITIVE_VALUE_RE.source, "gi"),
+    (match, key: string | undefined) => {
+      if (SENSITIVE_KEY_RE.test(key ?? "")) {
+        reasons.add("contains sensitive key");
+        return `${key}=[redacted]`;
+      }
+      return match;
     }
-    return match;
-  });
+  );
 }
 
 function redactPaths(text: string, reasons: Set<string>): string {

--- a/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
+++ b/orchestrate/skills/orchestrate/scripts/core/redact-body.ts
@@ -6,7 +6,7 @@ const SENSITIVE_ASSIGNMENT_RE =
 // end of line, an unquoted-word boundary followed by `,`/`;`/`}` (JSON-ish
 // contexts), or a closing quote. Everything between belongs to the secret and
 // gets redacted whole — including values with spaces (`Bearer eyJ... sig`).
-const SENSITIVE_VALUE_RE = /[^,;}\n"']*(?:"[^"]*"?|'[^']*'?|$|\s(?=[\w"'])|$)/;
+const SENSITIVE_VALUE_RE = /[^,;}\n"']*(?:["'][^"']*["']?|[,;}]?)/;
 const PATH_PATTERNS = [
   { re: /^\/workspace\/\S*/gm, reason: "contains /workspace path" },
   { re: /^\/Users\/\S*/gm, reason: "contains /Users path" },


### PR DESCRIPTION
## What

`redactBody`'s `SENSITIVE_ASSIGNMENT_RE` wraps the key alternatives in `\b`. A key that sits next to a quote character - exactly how it appears in a pasted JSON body - never matches, because `"` is a non-word character and the boundary logic inverts at it:

```
{"Authorization": "Bearer eyJhbG.sig"}   -> no redaction, reasons: []
{"api_key": "sk-123", "name": "x"}       -> no redaction, reasons: []
```

The same pattern also stops the value at the first space (`\S+`), which is #242's point: `api_key = super secret value here` kept the tail (`secret value here"`) in the returned body.

## The fix

Two changes to the one pattern:

1. **Optional surrounding quotes on the key** - `"?"key"?"`, so quoted JSON keys match while bare keys keep matching as before.
2. **Lazy whole-value capture** instead of `\S+` - the value runs to a real assignment boundary: end of line, an unquoted `,` / `;` / `}` (JSON-ish contexts), or the closing quote. Values containing spaces (`Bearer <jwt>`) are redacted whole.

Behaviour preserved:

```
password: hunter2                        -> password=[redacted]
blocked: docker rate-limit on redis:7    -> unchanged (no sensitive key)
the authorization header was missing     -> unchanged (no assignment)
```

## Relation to #242

#242 (open PR) fixes the value-side truncation. This PR fixes the **key side** - the `\b`-vs-quote interaction that lets pasted JSON bodies through with zero redaction - which that PR does not touch; its own before/after examples still leak when the body is JSON-shaped. Both changes compose cleanly; happy to rebase on whichever lands first.

## Tests

Extended `redact-body.test.ts` with the quoted-JSON case, values containing spaces, and non-redaction of ordinary prose. 6/6 passing locally (repo tests run under `bun:test`; verified with a local vitest shim since bun is not installed on this machine).

Note for reviewers: the value-boundary regex treats `'` and `"` inside unquoted values as terminators, so a secret containing a literal quote character would be truncated there. That is strictly better than the current behaviour (which truncated at the first space) and keeps the pattern a single pass; flagging it deliberately rather than over-fitting the regex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret-redaction regex used before posting comment bodies. The change is defensive, but incomplete matching can still leak credentials, so the new patterns need careful review.
> 
> **Overview**
> Fixes `redactBody` leaking secrets in pasted JSON and space-containing values. Quoted keys like `"api_key"` now match, and values are redacted as a whole instead of stopping at the first space (`Bearer <jwt>` tails no longer leak).
> 
> Quoted values now close with the same quote that opened them (so apostrophes inside `"it's a secret"` are not treated as terminators). Unquoted values run to `,` / `;` / `}` and consume that separator so the assignment actually matches.
> 
> Tests cover JSON bodies, spaced quoted values, unquoted separator cases, and inner apostrophes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1be9ac5e88430411c0d2883ae48d5ea402cbc52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->