### PR TITLE
Add HOL Guard third-party security plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -174,6 +174,11 @@
       "description": "Search people and companies, enrich leads, run sequences."
     },
     {
+      "name": "hol-guard",
+      "source": "third_party/hol-guard",
+      "description": "Runtime and supply-chain security for Cursor and other AI coding agents."
+    },
+    {
       "name": "klaviyo",
       "source": "third_party/klaviyo",
       "description": "Manage profiles, segments, campaigns, and flows."
@@ -310,5 +315,3 @@
     }
   ]
 }
-
-

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `juicebox` | [Juicebox](third_party/juicebox/) | Cursor | Integrations | Query recruiting analytics, shortlists, and sourcing agents. |
 | `outreach` | [Outreach](third_party/outreach/) | Cursor | Integrations | Search sequences, prospects, and Kaia meetings. |
 | `amplemarket` | [Amplemarket](third_party/amplemarket/) | Cursor | Integrations | Search people and companies, enrich leads, run sequences. |
+| `hol-guard` | [HOL Guard](third_party/hol-guard/) | Hashgraph Online | Developer Tools | Runtime and supply-chain security for Cursor and other AI coding agents. |
 | `klaviyo` | [Klaviyo](third_party/klaviyo/) | Cursor | Integrations | Manage profiles, segments, campaigns, and flows. |
 | `customer-io` | [Customer.io](third_party/customer-io/) | Cursor | Integrations | Build campaigns, manage segments, and query people. |
 | `mailerlite` | [MailerLite](third_party/mailerlite/) | Cursor | Integrations | Manage subscribers, groups, campaigns, and automations. |

--- a/third_party/hol-guard/.cursor-plugin/plugin.json
+++ b/third_party/hol-guard/.cursor-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "hol-guard",
+  "displayName": "HOL Guard",
+  "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Runtime and supply-chain security for Cursor and other AI coding agents.",
+  "author": {
+    "name": "Hashgraph Online"
+  },
+  "homepage": "https://hol.org/guard",
+  "repository": "https://github.com/hashgraph-online/hol-guard",
+  "license": "MIT",
+  "keywords": [
+    "hol-guard",
+    "security",
+    "ai-security",
+    "runtime-security",
+    "supply-chain",
+    "cursor"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "security",
+    "ai",
+    "cursor",
+    "runtime"
+  ]
+}

--- a/third_party/hol-guard/CHANGELOG.md
+++ b/third_party/hol-guard/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0
+
+- Add the HOL Guard Cursor marketplace plugin.
+- Add a focused skill for guided Guard setup, Cursor harness protection, diagnostics, approvals, and receipts.

--- a/third_party/hol-guard/LICENSE
+++ b/third_party/hol-guard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hashgraph Online
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/hol-guard/README.md
+++ b/third_party/hol-guard/README.md
@@ -1,0 +1,58 @@
+# HOL Guard
+
+Cursor plugin that adds an agent skill for setting up and operating [HOL Guard](https://github.com/hashgraph-online/hol-guard), an open-source runtime and supply-chain security layer for AI agents.
+
+## Install
+
+1. Open **Cursor Settings → Plugins**.
+2. Search for **HOL Guard**.
+3. Click **Install**.
+
+Or run `/add-plugin hol-guard` in chat.
+
+## Set up Guard
+
+HOL Guard is a separate local CLI. The plugin does not bundle or silently install the runtime.
+
+```bash
+pipx install hol-guard
+hol-guard init
+```
+
+`hol-guard init` is the preferred guided setup: it discovers supported agent harnesses, shows the plan before side effects, and asks for approval at each checkpoint. For explicit Cursor harness setup, use:
+
+```bash
+hol-guard install cursor
+```
+
+Verify the local installation with:
+
+```bash
+hol-guard status
+hol-guard doctor
+```
+
+Review pending decisions and local evidence with:
+
+```bash
+hol-guard approvals
+hol-guard receipts
+```
+
+## Cursor security model
+
+HOL Guard supports Cursor, but it does not replace Cursor's native tool approval. The current Cursor integration respects native tool approval and focuses Guard on artifact trust before launch.
+
+`hol-guard command test` and `hol-guard command explain` are inspection-only helpers. They do not execute the command, apply final runtime policy, create an approval, or record a receipt. Use Guard's harness setup for protection rather than treating those commands as an enforcement wrapper.
+
+Guard works locally without a cloud account. Guard Cloud is optional for synchronized evidence, team policy, fleet visibility, and shared approval workflows.
+
+## Docs
+
+- HOL Guard: https://github.com/hashgraph-online/hol-guard
+- Product: https://hol.org/guard
+- Harness support: https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md
+
+## License
+
+This Cursor marketplace packaging is MIT licensed. HOL Guard itself is licensed Apache-2.0 in its upstream repository.

--- a/third_party/hol-guard/skills/hol-guard/SKILL.md
+++ b/third_party/hol-guard/skills/hol-guard/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: hol-guard
+description: Set up, verify, and operate HOL Guard security for Cursor. Use when a user wants Guard installation, Cursor harness protection, security status, approvals, receipts, or Guard diagnostics.
+---
+
+# HOL Guard
+
+Use HOL Guard's real CLI and current Cursor harness support. Do not substitute a generic security checklist for Guard execution.
+
+## Workflow
+
+1. Check whether Guard is available with `hol-guard --version`.
+2. If Guard is missing and the user asked to install or set it up, use `pipx install hol-guard` when `pipx` is available. Do not silently install system dependencies.
+3. Prefer `hol-guard init` for guided first-run setup. It discovers supported harnesses, shows the plan first, and gates side effects behind approvals.
+4. For explicit Cursor harness setup, use `hol-guard install cursor`.
+5. Verify the result with `hol-guard status` and `hol-guard doctor`.
+6. When Guard pauses or blocks work, inspect `hol-guard approvals` and `hol-guard receipts` instead of bypassing the decision.
+
+## Inspection versus enforcement
+
+`hol-guard command test '<command>'` gives a concise classification. `hol-guard command explain '<command>'` gives the evaluation trace. Both are side-effect free: they do not execute the command, apply final policy, create an approval, or record a receipt.
+
+Do not present those inspection commands as protection. Guard's harness setup is the protection path.
+
+## Cursor boundary
+
+Current HOL Guard support for Cursor respects Cursor's native tool approval and focuses Guard on artifact trust before launch. Do not claim that Guard replaces Cursor's native approvals or that every Cursor tool call is intercepted by Guard.
+
+## Guardrails
+
+- Do not auto-approve a Guard block or weaken Guard settings just to make a task continue.
+- Do not require Guard Cloud for local protection; cloud connection is optional.
+- Do not use `hol-guard init --yes` unless the user explicitly requested non-interactive automation and already approved the plan.
+- Do not confuse `plugin-scanner` with runtime protection. `plugin-scanner` is the separate maintainer/CI package for linting and verifying agent ecosystem packages.
+- Prefer `hol-guard status`, `hol-guard doctor`, `hol-guard approvals`, and `hol-guard receipts` for operational troubleshooting before inventing manual state changes.


### PR DESCRIPTION
## Problem

HOL Guard supports Cursor as a local AI-agent security harness, but Cursor users cannot currently discover or install Guard guidance through the official plugin marketplace. Setup is therefore disconnected from Cursor's native plugin/skill surface.

## Solution

- register `hol-guard` in the official marketplace under `third_party/hol-guard`
- add a focused Agent Skill for installing, initializing, verifying, and operating the real `hol-guard` CLI
- document the explicit Cursor harness setup path and Guard status/doctor/approval/receipt flows
- keep the security boundary accurate: Guard respects Cursor's native tool approval and currently focuses on artifact trust before launch for Cursor
- make clear that `hol-guard command test` / `command explain` are inspection-only and are not an enforcement wrapper
- keep Guard Cloud optional for local protection

The plugin does not bundle HOL Guard or silently install system dependencies. It gives Cursor a native marketplace/skill path into the maintained upstream runtime at https://github.com/hashgraph-online/hol-guard.

## Verification

- exact `HOL Guard` / `hol-guard` issue and PR dedupe in `cursor/plugins`: no existing result immediately before submission
- plugin and marketplace definitions validated against the repository's current `schemas/plugin.schema.json` and `schemas/marketplace.schema.json`
- marketplace name/source uniqueness checked
- `SKILL.md` uses Cursor's current `name` + `description` frontmatter convention
- install, init, status, doctor, approvals, receipts, command-inspection semantics, and Cursor's current approval boundary were cross-checked against the current HOL Guard `release/3.0` documentation
- no CLA/DCO or AI-disclosure requirement is declared in the repository; web commit signoff is not required

The repository's `Validate plugins` pull-request workflow should run `node scripts/validate-plugins.mjs` against the submitted branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive marketplace metadata and agent guidance only; no executable security enforcement or changes to core Cursor behavior in this repo.
> 
> **Overview**
> Adds **HOL Guard** (`third_party/hol-guard`) to the official Cursor marketplace and plugin table so users can install Hashgraph Online’s runtime/supply-chain security guidance from Settings or `/add-plugin hol-guard`.
> 
> The new package is manifest + docs only: `plugin.json`, MIT `LICENSE`, `CHANGELOG`, README, and a **`hol-guard` agent skill** that walks agents through the real `hol-guard` CLI (`pipx install`, `init`, `install cursor`, `status`/`doctor`, `approvals`/`receipts`). The skill and README stress that the plugin does **not** bundle or silently install Guard, that **`command test` / `command explain` are inspection-only**, and that on Cursor Guard **does not replace native tool approval** (artifact trust before launch). Guard Cloud stays optional for local use.
> 
> Also registers the entry in `.cursor-plugin/marketplace.json` and trims trailing blank lines at the end of that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3abd8b50590441ceb48d02dab4ee162842b0e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->