### PR TITLE
feat(pstack): add Agent Plugins v1 compatibility

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -18,6 +18,8 @@ fork it. improve it. make it yours. PRs are welcome!
 /add-plugin pstack
 ```
 
+pstack also includes a root [`plugin.json`](./plugin.json) for [Agent Plugins v1](https://agent-plugins.org/specification) clients. use your client's plugin flow to install the `pstack/` directory. the portable package exposes the skills under `skills/`; the two subagents under `agents/` remain cursor-specific.
+
 ## get started
 
 two steps:

--- a/pstack/plugin.json
+++ b/pstack/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "pstack",
+  "version": "0.14.2",
+  "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
+  "author": {
+    "name": "Lauren Tan"
+  },
+  "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "keywords": [
+    "pstack",
+    "poteto-mode",
+    "workflow",
+    "principles",
+    "agent-style",
+    "subagents",
+    "unslop"
+  ]
+}

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: Poteto Mode
+name: poteto-mode
 description: poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified work. Use for poteto, /poteto-mode, or requests to work in this style.
 disable-model-invocation: true
 mode: true
 icon: crown
 color: yellow
 reminder: New task? Playbook match or rigor needed -> apply /poteto-mode. Casual turn or user opts out -> don't.
+metadata:
+  cursor-display-name: Poteto Mode
 ---
 
 # Poteto mode


### PR DESCRIPTION
## Summary

- add a root `plugin.json` targeting Agent Plugins v1.0.0
- make the `poteto-mode` skill identifier match its directory and preserve the display label in standard metadata
- document the portable boundary: `skills/` travels across Agent Plugins clients, while the two subagents remain Cursor-specific

## Context

pstack already uses the standard fixed `skills/<name>/SKILL.md` layout, but Agent Plugins clients had no root manifest to discover it. Its main entry point also declared `name: Poteto Mode`, which violates the shared Agent Skills identifier rules.

The existing `.cursor-plugin/plugin.json` stays in place, so the Cursor marketplace keeps its native metadata and `agents/` support. The identifier change overlaps #240 and #241; it is included here because portable pstack needs that entry point to be valid on its own.

## Validation

- `node scripts/validate-plugins.mjs`
- validated `pstack/plugin.json` with AJV 2020 against the canonical v1.0.0 schema
- ran `skills-ref validate` across all 44 skills; after this identifier fix, its remaining diagnostics are only the existing Cursor-specific frontmatter extensions
- `git diff --check HEAD^ HEAD`

Closes #237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation only; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Adds a **root `plugin.json`** so Agent Plugins v1 clients can discover and install `pstack/` without relying on Cursor-only packaging. The manifest carries version, description, and keywords; **`.cursor-plugin/plugin.json` is unchanged** for the Cursor marketplace.
> 
> **`poteto-mode` skill frontmatter** now uses the directory-aligned identifier `poteto-mode` instead of `Poteto Mode`, with **`metadata.cursor-display-name`** preserving the human label in Cursor.
> 
> **README install section** documents installing via any Agent Plugins client, and clarifies portability: **`skills/`** is portable; **`agents/`** subagents stay Cursor-specific.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501f5cbbf498be31f67e1ffb2db187551748693c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->