### PR TITLE
fix: enable continual learning trial mode by default

### DIFF
--- a/continual-learning/README.md
+++ b/continual-learning/README.md
@@ -42,7 +42,7 @@ Default cadence:
 - minimum 120 minutes since the last run
 - transcript mtime must advance since the previous run
 
-Trial mode defaults (enabled in this plugin hook config):
+Trial mode defaults (enabled by default in this plugin):
 
 - minimum 3 completed turns
 - minimum 15 minutes

--- a/continual-learning/hooks/continual-learning-stop.test.ts
+++ b/continual-learning/hooks/continual-learning-stop.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const path_hook = join(import.meta.dir, "continual-learning-stop.ts");
+
+test("uses trial cadence by default", async () => {
+	const dir_workspace = mkdtempSync(join(tmpdir(), "continual-learning-"));
+	const path_transcript = join(dir_workspace, "transcript.jsonl");
+	writeFileSync(path_transcript, "{}\n");
+
+	try {
+		const outputs_hook = [];
+
+		for (let count_turn = 1; count_turn <= 3; count_turn += 1) {
+			outputs_hook.push(
+				await runHook(dir_workspace, path_transcript, count_turn)
+			);
+		}
+
+		expect(outputs_hook.slice(0, 2)).toEqual([{}, {}]);
+		expect(outputs_hook[2]).toHaveProperty("followup_message");
+	} finally {
+		rmSync(dir_workspace, { recursive: true, force: true });
+	}
+});
+
+async function runHook(
+	dir_workspace: string,
+	path_transcript: string,
+	count_turn: number
+): Promise<Record<string, unknown>> {
+	const env_hook = { ...process.env };
+	delete env_hook.CONTINUAL_LEARNING_TRIAL_MODE;
+	delete env_hook.CONTINUOUS_LEARNING_TRIAL_MODE;
+
+	const process_hook = Bun.spawn(["bun", "run", path_hook], {
+		cwd: dir_workspace,
+		env: env_hook,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const input_hook = {
+		conversation_id: "trial-default-test",
+		generation_id: `generation-${count_turn}`,
+		status: "completed",
+		loop_count: 0,
+		transcript_path: path_transcript,
+	};
+
+	process_hook.stdin.write(JSON.stringify(input_hook));
+	process_hook.stdin.end();
+
+	const [status_exit, text_stdout, text_stderr] = await Promise.all([
+		process_hook.exited,
+		new Response(process_hook.stdout).text(),
+		new Response(process_hook.stderr).text(),
+	]);
+	expect(status_exit, text_stderr).toBe(0);
+
+	return JSON.parse(text_stdout) as Record<string, unknown>;
+}

--- a/continual-learning/hooks/continual-learning-stop.ts
+++ b/continual-learning/hooks/continual-learning-stop.ts
@@ -160,7 +160,10 @@ async function main(): Promise<number> {
     const now = Date.now();
 
     const trialEnabled = parseBoolean(
-      readEnvValue("CONTINUAL_LEARNING_TRIAL_MODE", "CONTINUOUS_LEARNING_TRIAL_MODE")
+      readEnvValue(
+        "CONTINUAL_LEARNING_TRIAL_MODE",
+        "CONTINUOUS_LEARNING_TRIAL_MODE"
+      ) ?? "true"
     );
     if (trialEnabled && countedTurn && state.trialStartedAtMs === null) {
       state.trialStartedAtMs = now;


### PR DESCRIPTION
## Summary

- enable the documented continual-learning trial cadence when no trial-mode env override is set
- preserve explicit `CONTINUAL_LEARNING_TRIAL_MODE` and legacy env overrides
- add a regression test that exercises the installed hook for three completed turns
- clarify that trial mode is enabled by the plugin default, rather than by hook config

## Test plan

- `bun test continual-learning/hooks/continual-learning-stop.test.ts`
- `git diff --check`
- `jq empty continual-learning/hooks/hooks.json continual-learning/.cursor-plugin/plugin.json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change increases how often continual-learning may trigger for users who relied on the old implicit “trial off” default; no auth or data-handling impact.
> 
> **Overview**
> **Trial cadence now applies by default** when `CONTINUAL_LEARNING_TRIAL_MODE` (and the legacy alias) is not set. The stop hook treats a missing env value as `"true"` before `parseBoolean`, so new installs get the faster trial thresholds (3 turns / 15 minutes) instead of silently using only the long default cadence.
> 
> Explicit env overrides are unchanged: setting the trial-mode vars to `false` still disables trial behavior. Docs now state that trial mode is **enabled by default in the plugin**, not tied to hook config wording.
> 
> A **Bun integration test** spawns the stop hook three times with trial env vars cleared and asserts the third completed turn emits `followup_message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564b3e182ece87aa1c598c426e4e130058665e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->