### PR TITLE
Add AI prompt snippets plugin

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -74,6 +74,11 @@
       "description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence."
     },
     {
+      "name": "ai-prompt-snippets",
+      "source": "ai-prompt-snippets",
+      "description": "Reusable AI prompt commands for common coding workflows in Cursor."
+    },
+    {
       "name": "gmail",
       "source": "third_party/gmail",
       "description": "Search, read, draft, and manage email."

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `cursor-sdk` | [Cursor SDK](cursor-sdk/) | Cursor | Developer Tools | Build apps, scripts, and automations with the TypeScript SDK. |
 | `orchestrate` | [Orchestrate](orchestrate/) | Cursor | Developer Tools | Fan large tasks out across parallel cloud agents with planners, workers, verifiers, and structured handoffs. |
 | `pstack` | [pstack](pstack/) | Lauren Tan | Developer Tools | if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence. |
+| `ai-prompt-snippets` | [AI Prompt Snippets](ai-prompt-snippets/) | sarathkumar1207 | Developer Tools | Reusable AI prompt commands for common coding workflows in Cursor. |
 | `gmail` | [Gmail](third_party/gmail/) | Cursor | Productivity | Search, read, draft, and manage email. |
 | `google-drive` | [Google Drive](third_party/google-drive/) | Cursor | Productivity | Search, read, create, and share files. |
 | `google-calendar` | [Google Calendar](third_party/google-calendar/) | Cursor | Productivity | Search events and schedule meetings. |

--- a/ai-prompt-snippets/.cursor-plugin/plugin.json
+++ b/ai-prompt-snippets/.cursor-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "ai-prompt-snippets",
+  "displayName": "AI Prompt Snippets",
+  "version": "1.0.0",
+  "description": "Reusable AI prompt commands for common coding workflows in Cursor.",
+  "author": {
+    "name": "sarathkumar1207"
+  },
+  "homepage": "https://github.com/cursor/plugins",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "logo": "assets/logo.svg",
+  "keywords": [
+    "ai",
+    "prompts",
+    "commands",
+    "code-review",
+    "testing",
+    "documentation"
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "ai",
+    "prompts",
+    "productivity"
+  ],
+  "commands": "./commands/",
+  "skills": "./skills/"
+}

--- a/ai-prompt-snippets/CHANGELOG.md
+++ b/ai-prompt-snippets/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release with reusable AI prompt commands and a prompt-snippets skill.

--- a/ai-prompt-snippets/LICENSE
+++ b/ai-prompt-snippets/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sarathkumar1207
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ai-prompt-snippets/README.md
+++ b/ai-prompt-snippets/README.md
@@ -1,0 +1,21 @@
+# AI Prompt Snippets
+
+AI Prompt Snippets gives Cursor users reusable AI commands for everyday coding tasks.
+
+## Commands
+
+- Explain selected code
+- Review selected code
+- Write tests
+- Refactor for readability
+- Generate documentation
+
+## Skill
+
+The included `prompt-snippets` skill helps agents use concise, scoped prompts for common development workflows.
+
+## Usage
+
+Install the plugin in Cursor, open the command palette, and run one of the AI Prompt Snippets commands while a file or selection is active.
+
+For best results, select the relevant code before running a command.

--- a/ai-prompt-snippets/assets/logo.svg
+++ b/ai-prompt-snippets/assets/logo.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="128" height="128" rx="24" fill="#111827"/>
+  <path d="M32 38C32 32.477 36.477 28 42 28H86C91.523 28 96 32.477 96 38V90C96 95.523 91.523 100 86 100H42C36.477 100 32 95.523 32 90V38Z" fill="#F9FAFB"/>
+  <path d="M45 47H83" stroke="#111827" stroke-width="6" stroke-linecap="round"/>
+  <path d="M45 62H75" stroke="#2563EB" stroke-width="6" stroke-linecap="round"/>
+  <path d="M45 77H83" stroke="#111827" stroke-width="6" stroke-linecap="round"/>
+  <path d="M89 27L93 36L102 40L93 44L89 53L85 44L76 40L85 36L89 27Z" fill="#22C55E"/>
+</svg>

--- a/ai-prompt-snippets/commands/explain-selected-code.md
+++ b/ai-prompt-snippets/commands/explain-selected-code.md
@@ -1,0 +1,18 @@
+---
+name: explain-selected-code
+description: Explain the selected code clearly and identify important behavior, dependencies, and risks.
+---
+
+# Explain selected code
+
+Explain the selected code in clear, practical language.
+
+Include:
+
+- What the code does
+- The main control flow
+- Important inputs and outputs
+- External dependencies or side effects
+- Any confusing, risky, or surprising behavior
+
+Keep the explanation concise and point to specific lines or symbols when useful.

--- a/ai-prompt-snippets/commands/generate-docs.md
+++ b/ai-prompt-snippets/commands/generate-docs.md
@@ -1,0 +1,18 @@
+---
+name: generate-docs
+description: Generate concise documentation for the selected code, command, function, or module.
+---
+
+# Generate documentation
+
+Generate concise documentation for the selected code.
+
+Include:
+
+- Purpose
+- Inputs and outputs
+- Important options or configuration
+- Example usage when helpful
+- Known limitations or assumptions
+
+Match the documentation style already used in the project.

--- a/ai-prompt-snippets/commands/refactor-for-readability.md
+++ b/ai-prompt-snippets/commands/refactor-for-readability.md
@@ -1,0 +1,18 @@
+---
+name: refactor-for-readability
+description: Refactor selected code to improve readability while preserving existing behavior.
+---
+
+# Refactor for readability
+
+Refactor the selected code to improve readability without changing behavior.
+
+Guidelines:
+
+- Keep the change small and focused.
+- Preserve public APIs and observable behavior.
+- Prefer clearer names and simpler control flow.
+- Avoid introducing new dependencies.
+- Mention any behavior that could not be verified from local context.
+
+After the refactor, summarize the changes and recommend validation steps.

--- a/ai-prompt-snippets/commands/review-selected-code.md
+++ b/ai-prompt-snippets/commands/review-selected-code.md
@@ -1,0 +1,18 @@
+---
+name: review-selected-code
+description: Review selected code for bugs, edge cases, maintainability issues, and missing tests.
+---
+
+# Review selected code
+
+Review the selected code as if it is part of a pull request.
+
+Prioritize:
+
+- Bugs or incorrect behavior
+- Edge cases
+- Security or privacy risks
+- Missing tests
+- Readability and maintainability problems
+
+Report findings first, ordered by severity. For each finding, explain the risk and suggest a concrete fix.

--- a/ai-prompt-snippets/commands/write-tests.md
+++ b/ai-prompt-snippets/commands/write-tests.md
@@ -1,0 +1,16 @@
+---
+name: write-tests
+description: Generate focused tests for the selected code using the project's existing test style.
+---
+
+# Write tests
+
+Write focused tests for the selected code.
+
+Before writing tests:
+
+- Inspect nearby tests and reuse the existing style.
+- Cover normal behavior, edge cases, and failure paths.
+- Avoid broad rewrites unless the current code is hard to test.
+
+After writing tests, explain what scenarios are covered and how to run the relevant test command.

--- a/ai-prompt-snippets/skills/prompt-snippets/SKILL.md
+++ b/ai-prompt-snippets/skills/prompt-snippets/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: prompt-snippets
+description: Use reusable AI prompts for common coding workflows in Cursor, including explanations, reviews, tests, refactors, and documentation.
+---
+
+# Prompt snippets
+
+## When to use
+
+- You want a consistent prompt for a repeated AI coding task.
+- You are helping a beginner ask Cursor for better coding assistance.
+- You want review, test, refactor, or documentation prompts that are scoped to the current code.
+
+## Instructions
+
+1. Ask the user to select the relevant code or file when context is unclear.
+2. Prefer focused prompts that mention the expected output format.
+3. Preserve the existing project style unless the user asks for a broader change.
+4. Call out assumptions before making code changes.
+5. Suggest validation steps after generating or changing code.


### PR DESCRIPTION
## Summary
- add an AI Prompt Snippets plugin with reusable commands for common Cursor AI workflows
- include commands for code explanation, code review, test generation, readability refactors, and documentation
- register the plugin in the marketplace manifest and README

## Validation
- node scripts/validate-plugins.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive plugin content and manifest/README entries only; no changes to auth, data handling, or shared validation logic beyond the new marketplace entry.
> 
> **Overview**
> Introduces a new **`ai-prompt-snippets`** Cursor plugin and lists it in **`.cursor-plugin/marketplace.json`** and the root **`README.md`** plugins table.
> 
> The plugin ships five palette commands (explain, review, write tests, refactor for readability, generate docs) as markdown command definitions under **`commands/`**, plus a **`prompt-snippets`** agent skill. Packaging follows the usual plugin layout: **`plugin.json`**, MIT license, changelog, README, and logo asset—no application or marketplace runtime code changes beyond registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e432f88377802fe85c8267391c1cf9f4fa7d48d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->