### PR TITLE
Swap X plugin billing.write for developer.write and developer.billing.write

### DIFF
--- a/third_party/x/CHANGELOG.md
+++ b/third_party/x/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this plugin will be documented here.
 
+## 2.2.0 — developer scopes
+
+- Requested `developer.write` and `developer.billing.write`, and dropped `billing.write`, matching the scopes the X MCP server now advertises at `https://api.x.com/.well-known/oauth-protected-resource/mcp`.
+- Existing installs need to sign in to X again to pick up the new scopes.
+
 ## 2.1.0 — X MCP guide skill
 
 - Added the X MCP guide skill: tells agents how to handle sign-in, onboarding, and out-of-credits errors with simple user-facing messages, plus session-start, search, pagination, and cost-aware workflow rules.

--- a/third_party/x/README.md
+++ b/third_party/x/README.md
@@ -35,7 +35,8 @@ Or run `/add-plugin x` in chat.
           "block.write",
           "bookmark.read",
           "bookmark.write",
-          "billing.write",
+          "developer.billing.write",
+          "developer.write",
           "offline.access"
         ]
       }
@@ -56,6 +57,7 @@ Or run `/add-plugin x` in chat.
 | Lists | Read and manage your lists |
 | Bookmarks | Read and manage your bookmarks |
 | Blocks & mutes | Read your blocks and mutes; add or remove blocks |
+| Developer account | Read your X developer account settings and credit balance |
 
 Posting is not included: the plugin does not request the `tweet.write` scope, so agents cannot publish posts as you.
 
@@ -67,7 +69,7 @@ Requests run in your user context, so they count against your account's rate lim
 
 ## Scopes requested
 
-`tweet.read`, `users.read`, `follows.read`, `space.read`, `mute.read`, `like.read`, `list.read`, `list.write`, `block.read`, `block.write`, `bookmark.read`, `bookmark.write`, `billing.write`, `offline.access`
+`tweet.read`, `users.read`, `follows.read`, `space.read`, `mute.read`, `like.read`, `list.read`, `list.write`, `block.read`, `block.write`, `bookmark.read`, `bookmark.write`, `developer.billing.write`, `developer.write`, `offline.access`
 
 ## X documentation search
 

--- a/third_party/x/mcp.json
+++ b/third_party/x/mcp.json
@@ -18,7 +18,8 @@
           "block.write",
           "bookmark.read",
           "bookmark.write",
-          "billing.write",
+          "developer.billing.write",
+          "developer.write",
           "offline.access"
         ]
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the X plugin's requested OAuth scopes: adds `developer.write` and `developer.billing.write`, and removes `billing.write`.

## Why

X's MCP server no longer advertises `billing.write`. Its protected-resource metadata at `https://api.x.com/.well-known/oauth-protected-resource/mcp` currently lists:

```
tweet.read, users.read, follows.read, space.read, mute.read, like.read,
list.read, list.write, block.read, block.write, bookmark.read, bookmark.write,
developer.billing.write, developer.write, offline.access
```

After this change the plugin's scope list matches that list exactly, in the same order.

## Changes

- `mcp.json`: the scope swap.
- `README.md`: the mirrored JSON block, the "Scopes requested" line, and a new row in the capabilities table for developer account and credit balance reads.
- `CHANGELOG.md`: 2.2.0 entry, noting that existing installs have to sign in to X again to pick up the new scopes.

## Verification

- `scripts/validate-plugins.mjs` passes.
- Compared the committed scope list against the live X metadata endpoint; the two are identical.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f30d5c6-9038-4ead-ba98-0b03d3cffe23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f30d5c6-9038-4ead-ba98-0b03d3cffe23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

