### PR TITLE
fix(create-plugin): document valid marketplace entry fields

### DIFF
--- a/create-plugin/skills/create-plugin-scaffold/SKILL.md
+++ b/create-plugin/skills/create-plugin-scaffold/SKILL.md
@@ -48,9 +48,10 @@ This path makes the plugin immediately available to Cursor without any install s
    - Agents: `agents/*.md` with `name`, `description`
    - Commands: `commands/*.(md|txt)` with `name`, `description`
 6. If repository uses `.cursor-plugin/marketplace.json`, add plugin entry:
-   - `name`
-   - `source`
-   - optional metadata (`description`, `keywords`, `category`, `tags`)
+   - Required: `name`, `source`
+   - Optional: `description`, `minClientVersions`
+   - Keep `keywords`, `category`, and `tags` in the plugin's
+     `.cursor-plugin/plugin.json`; they are not valid marketplace entry fields.
 7. Ensure all manifest paths are relative, valid, and do not use absolute paths or parent traversal.
 
 ## Guardrails


### PR DESCRIPTION
Closes #281

## Summary

- Document `name` and `source` as required marketplace plugin-entry fields.
- Document `description` and `minClientVersions` as optional fields.
- Clarify that `keywords`, `category` and `tags` belong in the plugin's `.cursor-plugin/plugin.json` manifest and are invalid in marketplace entries.

## Why

The `create-plugin-scaffold` skill previously recommended fields that are rejected by `schemas/marketplace.schema.json`. Following those instructions could produce a marketplace entry that fails repository validation.

## Validation

- `git diff --check`
- Validated `SKILL.md` YAML frontmatter
- Verified the documented fields match the marketplace schema
- Ran `node scripts/validate-plugins.mjs`
  - Result: `All plugins validated successfully.`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a scaffold skill; no runtime or schema behavior is modified.
> 
> **Overview**
> Updates the **create-plugin-scaffold** skill so step 6 matches `schemas/marketplace.schema.json` instead of suggesting fields that fail validation.
> 
> Marketplace plugin entries are documented as requiring **`name`** and **`source`**, with optional **`description`** and **`minClientVersions`**. The skill now states that **`keywords`**, **`category`**, and **`tags`** belong in `.cursor-plugin/plugin.json`, not in marketplace entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256bd2b1df6fdd427aca0a5378303dc80ea36c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->