### PR TITLE
fix(ralph-loop): require tagged completion promise

### DIFF
--- a/ralph-loop/hooks/capture-response.sh
+++ b/ralph-loop/hooks/capture-response.sh
@@ -37,7 +37,17 @@ if [[ -z "$RESPONSE_TEXT" ]]; then
 fi
 
 # Check for <promise>TEXT</promise> in the response
-PROMISE_TEXT=$(echo "$RESPONSE_TEXT" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
+PROMISE_TEXT=$(
+  printf '%s' "$RESPONSE_TEXT" |
+    perl -0777 -ne '
+      if (/<promise>(.*?)<\/promise>/s) {
+        my $promise = $1;
+        $promise =~ s/^\s+|\s+$//g;
+        $promise =~ s/\s+/ /g;
+        print $promise;
+      }
+    ' 2>/dev/null || true
+)
 
 if [[ -n "$PROMISE_TEXT" ]] && [[ "$PROMISE_TEXT" = "$COMPLETION_PROMISE" ]]; then
   touch "$DONE_FLAG"

--- a/ralph-loop/hooks/tests/capture-response.test.sh
+++ b/ralph-loop/hooks/tests/capture-response.test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HOOK="$SCRIPT_DIR/../capture-response.sh"
+TEST_PROJECT=$(mktemp -d)
+STATE_DIR="$TEST_PROJECT/.cursor/ralph"
+DONE_FLAG="$STATE_DIR/done"
+
+cleanup() {
+  rm -rf "$TEST_PROJECT"
+}
+trap cleanup EXIT
+
+mkdir -p "$STATE_DIR"
+cat >"$STATE_DIR/scratchpad.md" <<'EOF'
+---
+iteration: 1
+max_iterations: 10
+completion_promise: "ALL TESTS PASS"
+---
+Run the requested task.
+EOF
+
+run_case() {
+  local name=$1
+  local response=$2
+  local expected=$3
+  local actual="absent"
+
+  rm -f "$DONE_FLAG"
+  jq -n --arg text "$response" '{text: $text}' |
+    CURSOR_PROJECT_DIR="$TEST_PROJECT" bash "$HOOK"
+
+  if [[ -f "$DONE_FLAG" ]]; then
+    actual="present"
+  fi
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: $name (expected done flag $expected, got $actual)" >&2
+    return 1
+  fi
+
+  echo "PASS: $name"
+}
+
+run_case "untagged matching text" "ALL TESTS PASS" "absent"
+run_case "tagged matching text" \
+  "Finished: <promise>ALL TESTS PASS</promise>" "present"
+run_case "tagged text with normalized whitespace" \
+  $'<promise>\n  ALL   TESTS\n  PASS  \n</promise>' "present"
+run_case "tagged non-matching text" \
+  "<promise>TESTS FAILED</promise>" "absent"
+run_case "missing closing tag" "<promise>ALL TESTS PASS" "absent"
+run_case "empty response" "" "absent"


### PR DESCRIPTION
Closes #282

## Summary

- Extract completion promises only from complete `<promise>...</promise>` tags.
- Use `printf` instead of `echo` to preserve response text during extraction.
- Add integration regression tests covering tagged, untagged, malformed, mismatched, empty and whitespace-normalized responses.

## Why

The previous Perl expression used `-p`, which prints the complete response even when the `<promise>` substitution does not match.

As a result, an untagged response that exactly matched the configured completion promise could create the Ralph done flag and prematurely terminate the loop.

The updated extractor prints text only after finding a complete promise tag.

## Validation

- `git diff --check`
- `shfmt` formatting check
- `bash -n` on the Ralph hook and test scripts
- `bash ralph-loop/hooks/tests/capture-response.test.sh`
  - All six regression cases passed
- `node scripts/validate-plugins.mjs`
  - Result: `All plugins validated successfully.`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped hook behavior fix with regression tests; only affects when the Ralph loop marks itself done, with stricter (safer) completion detection.
> 
> **Overview**
> Fixes a bug where the Ralph **afterAgentResponse** hook could end the loop when the assistant’s plain text matched `completion_promise`, even without `<promise>...</promise>` tags. The old Perl `-p` path could leave the full response as “extracted” promise text on non-matches.
> 
> Promise extraction now uses `printf` (avoids `echo` mangling) and Perl that **only** emits inner text when a **complete** tag pair exists, still trimming and collapsing whitespace before comparing to the configured promise.
> 
> Adds `capture-response.test.sh` with six integration cases: untagged match must **not** set `done`, valid tagged matches (including multiline/whitespace), wrong promise, missing closing tag, and empty input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ebae5e6c67b14f5e23bdb918492c38671b0407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->