### PR TITLE
Bump Microsoft plugin min client versions

### DIFF
--- a/third_party/onedrive/.cursor-plugin/plugin.json
+++ b/third_party/onedrive/.cursor-plugin/plugin.json
@@ -3,7 +3,8 @@
   "displayName": "OneDrive",
   "version": "1.0.0",
   "minClientVersions": {
-    "cursor": "3.13.0"
+    "cursor": "3.19.0",
+    "sand": "0.30.0"
   },
   "description": "Browse, search, and read files.",
   "author": {

--- a/third_party/outlook-calendar/.cursor-plugin/plugin.json
+++ b/third_party/outlook-calendar/.cursor-plugin/plugin.json
@@ -3,7 +3,8 @@
   "displayName": "Outlook Calendar",
   "version": "1.0.0",
   "minClientVersions": {
-    "cursor": "3.13.0"
+    "cursor": "3.19.0",
+    "sand": "0.30.0"
   },
   "description": "List, create, update, and cancel calendar events.",
   "author": {

--- a/third_party/outlook/.cursor-plugin/plugin.json
+++ b/third_party/outlook/.cursor-plugin/plugin.json
@@ -3,7 +3,8 @@
   "displayName": "Outlook",
   "version": "1.0.0",
   "minClientVersions": {
-    "cursor": "3.13.0"
+    "cursor": "3.19.0",
+    "sand": "0.30.0"
   },
   "description": "Search, read, and send email, and look up contacts.",
   "author": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `minClientVersions` for the three Microsoft plugins (Outlook, Outlook Calendar, OneDrive):

- `cursor`: 3.13.0 → 3.19.0
- `sand`: 0.30.0 (new)

Validated with `scripts/validate-plugins.mjs` (all plugins pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9f3ae68-cdcd-4a51-9542-89c72155bb42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9f3ae68-cdcd-4a51-9542-89c72155bb42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

