### PR TITLE
fix(x): align skill name with directory

### DIFF
--- a/third_party/x/skills/x-api-mcp-guide/SKILL.md
+++ b/third_party/x/skills/x-api-mcp-guide/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: X MCP guide
+name: x-api-mcp-guide
 description: >-
   ALWAYS read this when a user connects the X plugin or any X MCP, before using
   any X connection, and again on any X error. Do not call an X tool until this


### PR DESCRIPTION
## Summary

Aligns the X plugin skill frontmatter name with its x-api-mcp-guide directory so skill-pack health checks can identify it consistently.

## Testing

- node scripts/validate-plugins.mjs — All plugins validated successfully.
- Verified the SKILL.md name equals the containing directory basename.

Fixes #269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only rename in SKILL.md frontmatter; no runtime logic, API, or guide content changes.
> 
> **Overview**
> Updates the X plugin skill frontmatter **`name`** from `X MCP guide` to **`x-api-mcp-guide`** so it matches the `skills/x-api-mcp-guide/` directory basename.
> 
> That alignment lets plugin/skill-pack health checks (e.g. `validate-plugins.mjs`) identify the skill consistently. **No behavioral or documentation body changes**—only the YAML `name` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d7e80a8b803523e5f914df4e6b0e8324e31851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->