### PR TITLE
Mention Microsoft in Outlook and OneDrive plugin descriptions

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -311,17 +311,17 @@
     {
       "name": "outlook",
       "source": "third_party/outlook",
-      "description": "Search, read, and send email, and look up contacts."
+      "description": "Search, read, and send Microsoft Outlook email, and look up contacts."
     },
     {
       "name": "outlook-calendar",
       "source": "third_party/outlook-calendar",
-      "description": "List, create, update, and cancel calendar events."
+      "description": "List, create, update, and cancel Microsoft Outlook calendar events."
     },
     {
       "name": "onedrive",
       "source": "third_party/onedrive",
-      "description": "Browse, search, and read files."
+      "description": "Browse, search, and read Microsoft OneDrive files."
     }
   ]
 }

--- a/third_party/onedrive/.cursor-plugin/plugin.json
+++ b/third_party/onedrive/.cursor-plugin/plugin.json
@@ -6,7 +6,7 @@
     "cursor": "3.19.0",
     "sand": "0.30.0"
   },
-  "description": "Browse, search, and read files.",
+  "description": "Browse, search, and read Microsoft OneDrive files.",
   "author": {
     "name": "Cursor",
     "email": "plugins@cursor.com"

--- a/third_party/outlook-calendar/.cursor-plugin/plugin.json
+++ b/third_party/outlook-calendar/.cursor-plugin/plugin.json
@@ -6,7 +6,7 @@
     "cursor": "3.19.0",
     "sand": "0.30.0"
   },
-  "description": "List, create, update, and cancel calendar events.",
+  "description": "List, create, update, and cancel Microsoft Outlook calendar events.",
   "author": {
     "name": "Cursor",
     "email": "plugins@cursor.com"

--- a/third_party/outlook/.cursor-plugin/plugin.json
+++ b/third_party/outlook/.cursor-plugin/plugin.json
@@ -6,7 +6,7 @@
     "cursor": "3.19.0",
     "sand": "0.30.0"
   },
-  "description": "Search, read, and send email, and look up contacts.",
+  "description": "Search, read, and send Microsoft Outlook email, and look up contacts.",
   "author": {
     "name": "Cursor",
     "email": "plugins@cursor.com"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds "Microsoft" to the plugin descriptions for Outlook, Outlook Calendar, and OneDrive so the brand is clear in marketplace listings.

- `outlook`: "Search, read, and send Microsoft Outlook email, and look up contacts."
- `outlook-calendar`: "List, create, update, and cancel Microsoft Outlook calendar events."
- `onedrive`: "Browse, search, and read Microsoft OneDrive files."

Updated both each plugin's `.cursor-plugin/plugin.json` and the top-level `.cursor-plugin/marketplace.json` so the two stay in sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da833026-220e-473f-9118-e2bfd8bbbe10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da833026-220e-473f-9118-e2bfd8bbbe10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

