### PR TITLE
fix(pstack): disable model invocation for five skills

### DIFF
--- a/pstack/skills/how/SKILL.md
+++ b/pstack/skills/how/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: how
 description: "Use for \"how does X work\", code walkthroughs before changing something, and placement / ownership / layering questions (\"where should this live\", \"which package owns this\", \"is this the right layer\"). Explains subsystem architecture, runtime flow, onboarding mental models. Can critique architecture. Use why for motivation."
+disable-model-invocation: true
 ---
 
 # How

--- a/pstack/skills/make-bot-ui/SKILL.md
+++ b/pstack/skills/make-bot-ui/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Use when building a custom UI (page, dashboard, buttons) that should wake a
   Grok Bot over a webhook, when the user must provide a webhook sender key, or
   when exposing that UI on Tailscale.
+disable-model-invocation: true
 ---
 # How to make a bot UI
 

--- a/pstack/skills/typescript-best-practices/SKILL.md
+++ b/pstack/skills/typescript-best-practices/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: typescript-best-practices
 description: TypeScript best practices. Use when reading or editing any .ts or .tsx file.
+disable-model-invocation: true
 ---
 
 # TypeScript best practices

--- a/pstack/skills/unslop/SKILL.md
+++ b/pstack/skills/unslop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: unslop
 description: Cut AI tells from any writing. Must always apply.
+disable-model-invocation: true
 ---
 
 # Unslop

--- a/pstack/skills/why/SKILL.md
+++ b/pstack/skills/why/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: why
 description: "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thresholds. Discovers available MCPs and queries each evidence category (source control, issue tracker, long-form docs, real-time chat, infrastructure observability, error tracking, product analytics warehouse) in parallel, then returns a cited read on decisions and tradeoffs. Use how for runtime behavior."
+disable-model-invocation: true
 ---
 
 # Why


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `disable-model-invocation: true` to the five named pstack skills.
- Keep `setup-pstack` and all other files unchanged.

## Testing
- Verified the branch changes exactly the five requested files.
- Verified each file differs from `main` by only the new frontmatter line.
- Verified `setup-pstack` is unchanged and still lacks the flag.
- Ran `git diff --check origin/main...HEAD`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25a695b0-1267-4c80-a133-0990451252b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25a695b0-1267-4c80-a133-0990451252b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

