### PR TITLE
fix: match SKILL.md name to folder basename x-api-mcp-guide

### DIFF
--- a/third_party/x/skills/x-api-mcp-guide/SKILL.md
+++ b/third_party/x/skills/x-api-mcp-guide/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: X MCP guide
+name: x-api-mcp-guide
 description: >-
   ALWAYS read this when a user connects the X plugin or any X MCP, before using
   any X connection, and again on any X error. Do not call an X tool until this


### PR DESCRIPTION
Fixes #269 - The X plugin SKILL.md has name 'X MCP guide' but the folder is 'x-api-mcp-guide'. Skill-pack health checks require name to equal the directory basename.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only rename in SKILL.md frontmatter; no runtime or API impact.
> 
> **Overview**
> Updates the X plugin skill frontmatter so **`name`** is **`x-api-mcp-guide`** instead of **`X MCP guide`**, matching the **`skills/x-api-mcp-guide/`** directory basename required by skill-pack health checks (fixes #269). No behavior or guide body content changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2d85411450a5cd35e314bd4190598584bee2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->