### PR TITLE
fix(pstack): require --attach on visual PRs

### DIFF
--- a/pstack/skills/poteto-mode/playbooks/opening-a-pr.md
+++ b/pstack/skills/poteto-mode/playbooks/opening-a-pr.md
@@ -18,7 +18,9 @@ Invoked at the end of every other playbook.
 - `## Blast Radius`. State who and what the change touches. Explain why the change is safe or risky. If main is red without the fix, name the continuing cost.
 - `## Verification`. State how you ran each check and its rigor. Name the real path, such as `control-cli`, `control-ui`, or the targeted tests. State the outcome of each check, not only the command name.
 
-**Media.** For a visual UI change, `gh pr create` (or `gh pr edit`) must pass `--attach` for before and after. Dump numbers and local artifact paths do not count. Before you paste the PR URL, `gh pr view --json body` must contain `user-attachments`. If it does not, the PR is not open. Do not use `## Summary` or `## Test plan` boilerplate. A commit body does not restate its subject.
+**Media.** For a visual UI change, `gh pr create` (or `gh pr edit`) must pass `--attach` for before and after. Dump numbers and local artifact paths do not count. Before you paste the PR URL, `gh pr view --json body` must contain `user-attachments`. If it does not, the PR is not open.
+
+Do not use `## Summary` or `## Test plan` boilerplate. A commit body does not restate its subject.
 
 **Forge.** Resolve the forge before the first PR operation and keep that choice for create, edit, view, watch, and merge. GitHub CLI (`gh`) is the default. If `command -v origin` succeeds and Origin can resolve the repository, prefer `origin pr ...`; if Origin is absent or cannot resolve the repository, stay on `gh` and record the fallback. Do not require Graphite (`gt`).
 

--- a/pstack/skills/poteto-mode/playbooks/opening-a-pr.md
+++ b/pstack/skills/poteto-mode/playbooks/opening-a-pr.md
@@ -18,7 +18,7 @@ Invoked at the end of every other playbook.
 - `## Blast Radius`. State who and what the change touches. Explain why the change is safe or risky. If main is red without the fix, name the continuing cost.
 - `## Verification`. State how you ran each check and its rigor. Name the real path, such as `control-cli`, `control-ui`, or the targeted tests. State the outcome of each check, not only the command name.
 
-After these sections, attach videos or screenshots when they prove a claim. Do not use `## Summary` or `## Test plan` boilerplate. A commit body does not restate its subject.
+**Media.** For a visual UI change, `gh pr create` (or `gh pr edit`) must pass `--attach` for before and after. Dump numbers and local artifact paths do not count. Before you paste the PR URL, `gh pr view --json body` must contain `user-attachments`. If it does not, the PR is not open. Do not use `## Summary` or `## Test plan` boilerplate. A commit body does not restate its subject.
 
 **Forge.** Resolve the forge before the first PR operation and keep that choice for create, edit, view, watch, and merge. GitHub CLI (`gh`) is the default. If `command -v origin` succeeds and Origin can resolve the repository, prefer `origin pr ...`; if Origin is absent or cannot resolve the repository, stay on `gh` and record the fallback. Do not require Graphite (`gt`).
 


### PR DESCRIPTION
## Why

Agents treat UI dump numbers and local artifact paths as verification. Reviewers open GitHub and see no screenshot. The old line asked to attach media when it proved a claim. That left the attach optional.

## Scope

`pstack/skills/poteto-mode/playbooks/opening-a-pr.md`. Replaces the trailing attach sentence with a Media gate. `gh pr create` or `gh pr edit` must pass `--attach` for before and after on a visual UI change. `gh pr view --json body` must contain `user-attachments` before the PR URL is pasted. Dump numbers and local paths do not count.

## Blast Radius

Poteto-mode agents that open PRs. Non-visual PRs are unchanged. No runtime product code.

## Verification

This PR is a playbook edit, not a visual UI change, so `--attach` does not apply. `gh pr view --json body` after create confirms the PR is open.


Made with [Cursor](https://cursor.com)