### PR TITLE
docs: pin mcp.json vs .mcp.json for dual Cursor + Claude Code plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ plugins/
 │   │   └── plugin.json        # Per-plugin manifest
 │   ├── skills/                # Agent skills (SKILL.md with frontmatter)
 │   ├── rules/                 # Cursor rules (.mdc files)
-│   ├── mcp.json               # MCP server definitions
+│   ├── mcp.json               # MCP server definitions (Cursor default)
 │   ├── README.md
 │   ├── CHANGELOG.md
 │   └── LICENSE

--- a/create-plugin/skills/create-plugin-scaffold/SKILL.md
+++ b/create-plugin/skills/create-plugin-scaffold/SKILL.md
@@ -48,8 +48,8 @@ This path makes the plugin immediately available to Cursor without any install s
    - Agents: `agents/*.md` with `name`, `description`
    - Commands: `commands/*.(md|txt)` with `name`, `description`
 6. If the component set includes `mcpServers`, create `mcp.json` at the plugin root with the server definitions.
-   - Cursor auto-discovers `mcp.json` (no dot prefix). `.mcp.json` is Claude Code's default and is not auto-discovered by Cursor.
-   - If the repo also ships a `.mcp.json` for Claude Code with different server config, pin `mcpServers` in `plugin.json` to the intended file (e.g. `"mcpServers": "./mcp.json"`) so Cursor never loads the wrong one.
+   - The plugins reference documents `mcp.json` as the default MCP config filename. Claude Code's default is `.mcp.json`.
+   - If the repo also ships a `.mcp.json` for Claude Code with different server config, pin `mcpServers` in `plugin.json` to the intended file (e.g. `"mcpServers": "./mcp.json"`) so the Marketplace clone uses the correct one.
 7. If repository uses `.cursor-plugin/marketplace.json`, add plugin entry:
    - `name`
    - `source`

--- a/create-plugin/skills/create-plugin-scaffold/SKILL.md
+++ b/create-plugin/skills/create-plugin-scaffold/SKILL.md
@@ -47,11 +47,14 @@ This path makes the plugin immediately available to Cursor without any install s
    - Skills: `skills/<skill-name>/SKILL.md` with `name`, `description`
    - Agents: `agents/*.md` with `name`, `description`
    - Commands: `commands/*.(md|txt)` with `name`, `description`
-6. If repository uses `.cursor-plugin/marketplace.json`, add plugin entry:
+6. If the component set includes `mcpServers`, create `mcp.json` at the plugin root with the server definitions.
+   - Cursor auto-discovers `mcp.json` (no dot prefix). `.mcp.json` is Claude Code's default and is not auto-discovered by Cursor.
+   - If the repo also ships a `.mcp.json` for Claude Code with different server config, pin `mcpServers` in `plugin.json` to the intended file (e.g. `"mcpServers": "./mcp.json"`) so Cursor never loads the wrong one.
+7. If repository uses `.cursor-plugin/marketplace.json`, add plugin entry:
    - `name`
    - `source`
    - optional metadata (`description`, `keywords`, `category`, `tags`)
-7. Ensure all manifest paths are relative, valid, and do not use absolute paths or parent traversal.
+8. Ensure all manifest paths are relative, valid, and do not use absolute paths or parent traversal.
 
 ## Guardrails
 

--- a/create-plugin/skills/review-plugin-submission/SKILL.md
+++ b/create-plugin/skills/review-plugin-submission/SKILL.md
@@ -21,7 +21,8 @@ A plugin is implemented and needs a final quality check before submission or rel
    - Agents in `agents/` markdown files
    - Commands in `commands/` markdown or text files
    - Hooks in `hooks/hooks.json`
-   - MCP config in `mcp.json` (or `mcpServers` override)
+   - MCP config in `mcp.json` (or `mcpServers` override in `plugin.json`)
+   - If `.mcp.json` also exists (common in dual Cursor + Claude Code repos), verify MCP filename precedence (see below)
 3. Verify component metadata:
    - Skills include `name` and `description` frontmatter
    - Rules include valid frontmatter and clear guidance
@@ -33,6 +34,17 @@ A plugin is implemented and needs a final quality check before submission or rel
    - `README.md` states purpose, installation, and component coverage
    - optional logo path is valid and repository-hosted
 
+## MCP filename precedence
+
+Cursor plugins auto-discover MCP servers from `mcp.json` at the plugin root. The dotfile `.mcp.json` is Claude Code's default — not Cursor's.
+
+When both `mcp.json` and `.mcp.json` exist, Cursor loads `mcp.json`. To override this, set `mcpServers` in `plugin.json` to an explicit path (e.g. `"mcpServers": "./.mcp.json"`).
+
+**Dual Cursor + Claude Code repos.** Shipping both filenames is the natural layout when one repository is published as a plugin for both clients. If the two files contain different server configs (e.g. hosted HTTP for Cursor, local stdio for Claude Code), a Marketplace clone can start the wrong server when precedence is not pinned. Authors should either:
+
+- Keep a single shared file and point both clients at it, or
+- Pin `mcpServers` in `.cursor-plugin/plugin.json` to the intended file so Cursor never falls back to `.mcp.json`.
+
 ## Checklist
 
 - Manifest exists and parses as valid JSON
@@ -41,6 +53,7 @@ A plugin is implemented and needs a final quality check before submission or rel
 - No missing frontmatter on skills/rules/agents/commands
 - Plugin scope is clear and focused
 - Marketplace registration complete (if multi-plugin repo)
+- If both `mcp.json` and `.mcp.json` exist, either the payloads are identical or `mcpServers` is pinned in `plugin.json`
 
 ## Output
 

--- a/create-plugin/skills/review-plugin-submission/SKILL.md
+++ b/create-plugin/skills/review-plugin-submission/SKILL.md
@@ -22,7 +22,7 @@ A plugin is implemented and needs a final quality check before submission or rel
    - Commands in `commands/` markdown or text files
    - Hooks in `hooks/hooks.json`
    - MCP config in `mcp.json` (or `mcpServers` override in `plugin.json`)
-   - If `.mcp.json` also exists (common in dual Cursor + Claude Code repos), verify MCP filename precedence (see below)
+   - If `.mcp.json` also exists (common in dual Cursor + Claude Code repos), verify MCP filename handling (see below)
 3. Verify component metadata:
    - Skills include `name` and `description` frontmatter
    - Rules include valid frontmatter and clear guidance
@@ -34,16 +34,16 @@ A plugin is implemented and needs a final quality check before submission or rel
    - `README.md` states purpose, installation, and component coverage
    - optional logo path is valid and repository-hosted
 
-## MCP filename precedence
+## MCP filename handling
 
-Cursor plugins auto-discover MCP servers from `mcp.json` at the plugin root. The dotfile `.mcp.json` is Claude Code's default — not Cursor's.
+The plugins reference documents `mcp.json` at the plugin root as the default MCP config filename. Claude Code's default is `.mcp.json`.
 
-When both `mcp.json` and `.mcp.json` exist, Cursor loads `mcp.json`. To override this, set `mcpServers` in `plugin.json` to an explicit path (e.g. `"mcpServers": "./.mcp.json"`).
+When both `mcp.json` and `.mcp.json` exist at the plugin root with different contents, a Marketplace clone can start the unintended server. To control which file is used, set `mcpServers` in `plugin.json` to an explicit path (e.g. `"mcpServers": "./mcp.json"`).
 
-**Dual Cursor + Claude Code repos.** Shipping both filenames is the natural layout when one repository is published as a plugin for both clients. If the two files contain different server configs (e.g. hosted HTTP for Cursor, local stdio for Claude Code), a Marketplace clone can start the wrong server when precedence is not pinned. Authors should either:
+**Dual Cursor + Claude Code repos.** Shipping both filenames is the natural layout when one repository is published as a plugin for both clients. If the two files contain different server configs (e.g. hosted HTTP for Cursor, local stdio for Claude Code), the Marketplace clone may load the wrong one. Authors should either:
 
 - Keep a single shared file and point both clients at it, or
-- Pin `mcpServers` in `.cursor-plugin/plugin.json` to the intended file so Cursor never falls back to `.mcp.json`.
+- Pin `mcpServers` in `.cursor-plugin/plugin.json` to the intended file.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary

Warn dual Cursor + Claude Code authors: shipping both `mcp.json` and `.mcp.json` with different payloads can make a Marketplace clone start the wrong server. Pin `mcpServers` in `plugin.json` to the intended file.

Does **not** claim Cursor auto-picks `mcp.json` when both exist. Issue #252 observed the clone starting `.mcp.json`.

Fixes #252

## Changes

- `create-plugin/skills/review-plugin-submission/SKILL.md` — dual-file trap, pin `mcpServers` to control which file is used, checklist item
- `create-plugin/skills/create-plugin-scaffold/SKILL.md` — scaffold `mcp.json`; if `.mcp.json` also ships, pin `mcpServers`
- `README.md` — annotate `mcp.json` as the documented Cursor default filename

No runtime loader, schema, or validator changes.