### PR TITLE
fix(advisor): address hook scripts via CURSOR_PLUGIN_ROOT

### DIFF
--- a/advisor/hooks/hooks.json
+++ b/advisor/hooks/hooks.json
@@ -3,23 +3,23 @@
   "hooks": {
     "afterFileEdit": [
       {
-        "command": "./hooks/mark-pending.sh"
+        "command": "bash \"${CURSOR_PLUGIN_ROOT}/hooks/mark-pending.sh\""
       }
     ],
     "afterAgentResponse": [
       {
-        "command": "./hooks/capture-response.sh"
+        "command": "bash \"${CURSOR_PLUGIN_ROOT}/hooks/capture-response.sh\""
       }
     ],
     "subagentStop": [
       {
-        "command": "./hooks/record-consult.sh",
+        "command": "bash \"${CURSOR_PLUGIN_ROOT}/hooks/record-consult.sh\"",
         "matcher": "^advisor-subagent$"
       }
     ],
     "stop": [
       {
-        "command": "./hooks/stop-hook.sh",
+        "command": "bash \"${CURSOR_PLUGIN_ROOT}/hooks/stop-hook.sh\"",
         "loop_limit": 3
       }
     ]

--- a/advisor/skills/advisor/SKILL.md
+++ b/advisor/skills/advisor/SKILL.md
@@ -89,7 +89,7 @@ Do not consult for routine steps, for things you can verify yourself (run the te
    - Relevant tool results verbatim: error messages, stack traces, test output, diffs. Trim unrelated noise and mark trims with `[...]`, but never paraphrase evidence.
    - Current state: `git status --short`, `git diff --stat`, files you touched, anything half-done.
    - Your specific questions, the options you see, and your current leaning with reasons.
-   - The `transcript_path` from `state.json` when set, so the advisor can read the full conversation itself.
+   - The `transcript_path` from `state.json` when set and the mode is on in this conversation, so the advisor can read the full conversation itself.
    - No secrets. Redact tokens, keys, and `.env` values.
 3. Spawn the advisor in the foreground and wait for it:
    - `subagent_type: "advisor-subagent"`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #314 before the marketplace re-indexes `main`.

- **Hook paths.** `hooks.json` referenced its scripts as `./hooks/*.sh`, the same layout `ralph-loop` uses, which the plugin registry classifies as `public-invalid`. Plugin hooks do not run from the plugin directory, so those commands fail with exit 127 from any other cwd. Switched to `bash "${CURSOR_PLUGIN_ROOT}/hooks/*.sh"`, the form `continual-learning` uses, which indexes and runs cleanly. Verified by running the exact command strings from `/tmp` with `CURSOR_PLUGIN_ROOT` set: all four hooks exit 0 and update state as expected.
- **Docs.** One line of the skill's briefing checklist missed the previous commit: `transcript_path` is only forwarded when advisor mode is on in this conversation, matching the consult rules landed in #314.

## Verification

- `node scripts/validate-plugins.mjs` passes.
- Hook scripts unchanged; the 28-scenario simulated payload suite still passes, plus the cwd-independence check above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fb7c243-c46d-4899-a6d1-d83988dcd0dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fb7c243-c46d-4899-a6d1-d83988dcd0dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

