### PR TITLE
fix(pstack): accept PRs without checks

### DIFF
--- a/pstack/skills/poteto-mode/scripts/watch-pr/github.test.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/github.test.ts
@@ -63,6 +63,30 @@ describe("checks fallback chain", () => {
     expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
   });
 
+  it("accepts an empty check set confirmed by both readers", async () => {
+    const reader = fakeReader({
+      fastPath: {
+        kind: "unusable",
+        exitCode: 1,
+        stderr: "no checks reported on the feature branch",
+      },
+      rollupPages: [{ checks: [], endCursor: null }],
+    });
+    const read = await resolveChecks(reader, context);
+    expect(read.checks).toEqual([]);
+    expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
+  });
+
+  it("accepts valid empty fast-path JSON confirmed by the rollup", async () => {
+    const reader = fakeReader({
+      fastPath: { kind: "checks", checks: [] },
+      rollupPages: [{ checks: [], endCursor: null }],
+    });
+    const read = await resolveChecks(reader, context);
+    expect(read.checks).toEqual([]);
+    expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
+  });
+
   it("fails closed when both paths are empty", async () => {
     const reader = fakeReader({
       fastPath: {

--- a/pstack/skills/poteto-mode/scripts/watch-pr/github.test.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/github.test.ts
@@ -73,6 +73,7 @@ describe("checks fallback chain", () => {
       rollupPages: [{ checks: [], endCursor: null }],
     });
     const read = await resolveChecks(reader, context);
+    expect(read.source).toBe("graphql-rollup");
     expect(read.checks).toEqual([]);
     expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
   });
@@ -83,6 +84,7 @@ describe("checks fallback chain", () => {
       rollupPages: [{ checks: [], endCursor: null }],
     });
     const read = await resolveChecks(reader, context);
+    expect(read.source).toBe("gh-pr-checks");
     expect(read.checks).toEqual([]);
     expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
   });
@@ -99,6 +101,20 @@ describe("checks fallback chain", () => {
       ChecksUnavailable
     );
     expect(reader.calls).toEqual(["checksFastPath", "checkRollupPage:null"]);
+  });
+
+  it("fails closed when exit 1 has an unrelated error", async () => {
+    const reader = fakeReader({
+      fastPath: {
+        kind: "unusable",
+        exitCode: 1,
+        stderr: "resource not accessible by integration",
+      },
+      rollupPages: [{ checks: [], endCursor: null }],
+    });
+    await expect(resolveChecks(reader, context)).rejects.toBeInstanceOf(
+      ChecksUnavailable
+    );
   });
 });
 

--- a/pstack/skills/poteto-mode/scripts/watch-pr/github.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/github.ts
@@ -617,6 +617,15 @@ export async function resolveChecks(
   } while (after !== null);
   const fallback = nonEmpty(checks);
   if (fallback !== null) return { source: "graphql-rollup", checks: fallback };
+  const fastPathConfirmsEmpty =
+    fast.kind === "checks" ||
+    (fast.exitCode === 1 &&
+      /^no checks reported on the .+ branch\s*$/im.test(fast.stderr));
+  if (fastPathConfirmsEmpty)
+    return {
+      source: fast.kind === "checks" ? "gh-pr-checks" : "graphql-rollup",
+      checks: [],
+    };
   const suffix =
     fast.kind === "unusable"
       ? `fast path exit=${fast.exitCode}; GraphQL rollup was empty${firstLine(fast.stderr) ? `; ${firstLine(fast.stderr)}` : ""}`

--- a/pstack/skills/poteto-mode/scripts/watch-pr/policy.test.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/policy.test.ts
@@ -88,6 +88,23 @@ describe("readiness truth table", () => {
       blocker: { kind: "failing-checks" },
     });
   });
+
+  it("classifies a PR with no configured checks as CI-clean", async () => {
+    const reader = fakeReader({
+      fastPath: { kind: "checks", checks: [] },
+      rollupPages: [{ checks: [], endCursor: null }],
+    });
+    const snapshot = await readSnapshot({
+      reader,
+      context: context(2),
+      pendingHistory: "include",
+      allowDraft: false,
+    });
+    expect(snapshot.kind).toBe("open");
+    if (snapshot.kind !== "open") throw new Error("expected open snapshot");
+    expect(snapshot.ci.kind).toBe("ci-clean");
+    expect(snapshot.ci.all).toEqual([]);
+  });
 });
 
 describe("snapshot query planning", () => {

--- a/pstack/skills/poteto-mode/scripts/watch-pr/policy.test.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/policy.test.ts
@@ -105,6 +105,25 @@ describe("readiness truth table", () => {
     expect(snapshot.ci.kind).toBe("ci-clean");
     expect(snapshot.ci.all).toEqual([]);
   });
+
+  it("waits when a new head temporarily has no checks after prior CI passed", async () => {
+    const reader = fakeReader({
+      fastPath: { kind: "checks", checks: [] },
+      rollupPages: [{ checks: [], endCursor: null }],
+      commitRollups: [
+        { oid: "previous", state: "SUCCESS" },
+        { oid: "head", state: null },
+      ],
+    });
+    await expect(readSnapshot({
+      reader,
+      context: context(3),
+      pendingHistory: "include",
+      allowDraft: false,
+    })).rejects.toThrow(
+      "PR head has no checks yet after a previously checked commit"
+    );
+  });
 });
 
 describe("snapshot query planning", () => {

--- a/pstack/skills/poteto-mode/scripts/watch-pr/policy.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/policy.ts
@@ -1,4 +1,8 @@
-import { WatcherQueryError, resolveChecks } from "./github.ts";
+import {
+  ChecksUnavailable,
+  WatcherQueryError,
+  resolveChecks,
+} from "./github.ts";
 import type * as T from "./types.ts";
 import { nonEmpty } from "./types.ts";
 export function assessGitHubMerge(args: {
@@ -108,6 +112,10 @@ export async function readSnapshot(args: {
         pending: pending ?? [],
         github: merge.github,
       };
+    else if (checks.checks.length === 0 && merge.hadPreviousPassingCi)
+      throw new ChecksUnavailable(
+        "PR head has no checks yet after a previously checked commit"
+      );
     else if (pending !== null)
       ci = { ...base, kind: "ci-pending", failed: [], pending };
     else

--- a/pstack/skills/poteto-mode/scripts/watch-pr/types.ts
+++ b/pstack/skills/poteto-mode/scripts/watch-pr/types.ts
@@ -88,7 +88,7 @@ export type FailedCheck = Extract<Check, { readonly kind: "failed" }>;
 export type PendingCheck = Extract<Check, { readonly kind: "pending" }>;
 export interface CheckRead {
   readonly source: "gh-pr-checks" | "graphql-rollup";
-  readonly checks: NonEmpty<Check>;
+  readonly checks: readonly Check[];
 }
 export interface CommitRollup {
   readonly oid: string;
@@ -115,7 +115,7 @@ export type GitHubMergeAllowed =
 export type GitHubMergeAssessment = GitHubMergeAllowed | GitHubMergeRefusal;
 interface CiBase {
   readonly source: CheckRead["source"];
-  readonly all: NonEmpty<Check>;
+  readonly all: readonly Check[];
   readonly hadPreviousPassingCi: boolean;
 }
 export type CiFailing = CiBase & {


### PR DESCRIPTION
## Why

`watch-pr --status-only` retries forever when a mergeable pull request has no configured checks. `gh pr checks` reports that no checks exist, and the GraphQL rollup is empty, but `resolveChecks` treats every empty result as a query failure.

## Scope

- Adds failing coverage for empty fast-path and GraphQL check results.
- Lets `CheckRead.checks` and `CiBase.all` represent a valid empty check set.
- Accepts empty checks only when the fast path returns valid empty JSON or `gh` returns its exact no-checks message, and the GraphQL rollup is also empty.
- Preserves fail-closed behavior for credential and unrelated exit-1 errors.

## Tradeoffs

The no-checks detection depends on the current `gh` stderr message. If `gh` changes that text, the watcher fails closed and reports a query blocker instead of treating an error as clean CI.

## Blast Radius

The change affects PRs with zero checks. PRs with passing, pending, failed, or hidden GitHub rollups keep the existing paths. No plugin prompt or workflow text changes.

## Verification

Before the fix, three focused tests failed with `ChecksUnavailable`.

After the fix:

- `bun test watch-pr` passed 42 tests.
- `bun run typecheck` passed.
- A live `watch-pr --status-only` run against `liush2yuxjtu/pi-debug-mode#2` returned a status table instead of `RETRY` before a later GitHub API TLS timeout made the external check unavailable.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior for zero-check PRs and new heads after prior CI changed; empty detection depends on a fixed `gh` stderr string, so a message change would fail closed rather than silently mark CI clean.
> 
> **Overview**
> Fixes **`watch-pr --status-only`** looping on mergeable PRs that have **no CI checks**: when both `gh pr checks` and the GraphQL rollup are empty, the watcher now treats that as a valid empty check set instead of raising **`ChecksUnavailable`**.
> 
> **`resolveChecks`** returns an empty list only if the fast path is valid empty JSON **or** exit code 1 with GitHub’s exact “no checks reported on the … branch” stderr **and** the rollup paginates to zero checks; unrelated exit-1 errors (e.g. integration access) still fail closed. **`CheckRead.checks`** and snapshot **`ci.all`** are typed as ordinary arrays so **`ci-clean`** can carry `[]`.
> 
> **`readSnapshot`** adds a guard: if the head has no checks but an older commit had passing rollup CI, it throws **`ChecksUnavailable`** so a fresh push is waited on rather than marked clean. New tests cover empty-check acceptance, unrelated fast-path failures, no-check PR classification, and the post-push wait case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09591fc726fbc19074ec987fda474d6f3706bb3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->