### PR TITLE
fix(pstack): persist pstack-models in the repo

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -244,7 +244,7 @@ cursor already has a great plan mode which works great with pstack. but personal
 
 type [`/automate-me`](./skills/automate-me/SKILL.md). it mines your recent transcripts, drafts a `<your-name>-mode` skill from how you've actually worked, and routes through pstack underneath. you keep pstack as the base and end up with your own routing skill alongside `poteto-mode`.
 
-models are configurable too. type [`/setup-pstack`](./skills/setup-pstack/SKILL.md). it detects the models you have access to and writes a small always-applied rule mapping each role (code, judgment, the review panels) to a model. every skill reads it and falls back to sensible defaults when the rule is absent, so you override only what you want.
+models are configurable too. type [`/setup-pstack`](./skills/setup-pstack/SKILL.md). it detects the models you have access to and writes `.cursor/rules/pstack-models.mdc`, a small always-applied rule mapping each role (code, judgment, the review panels) to a model. every skill reads it and falls back to sensible defaults when the rule is absent, so you override only what you want.
 
 ## automations
 

--- a/pstack/docs/guide/01-setup.md
+++ b/pstack/docs/guide/01-setup.md
@@ -20,7 +20,7 @@ Run:
 /setup-pstack
 ```
 
-[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, shows you each role (code delegates, judgment, the review panels), and asks what you want. Answer the questions. It writes `~/.cursor/rules/pstack-models.mdc`, a small rule every pstack skill reads.
+[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, shows you each role (code delegates, judgment, the review panels), and asks what you want. Answer the questions. It writes `.cursor/rules/pstack-models.mdc` in the repo, a small rule every pstack skill reads. Commit the file so cloud agents receive it. Do not gitignore it.
 
 You only override what you care about. A role with no line in the rule keeps the skill's default. To restore a default later, delete that role's line, or just run `/setup-pstack` again.
 

--- a/pstack/skills/arena/SKILL.md
+++ b/pstack/skills/arena/SKILL.md
@@ -25,7 +25,7 @@ The N candidates will receive the same prompt, so the prompt is the contract. Ge
 
 1. State the artifact each candidate is producing.
 2. Derive the rubric. State what success looks like for *this* task, then turn it into 3-6 concrete gradeable criteria. Concrete: `Adds a --dry-run flag that skips writes`. Vague: `code is correct`. The rubric is the picker's tool in Phase D; candidates only see the task.
-3. Pick the runners. Use `arena runners` from `~/.cursor/rules/pstack-models.mdc` when present. Otherwise default to one each on `claude-fable-5-1-thinking-max`, `gpt-5.6-sol-max`, `grok-4.6-fast-xhigh`, `claude-opus-5-thinking-xhigh`. Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
+3. Pick the runners. Use `arena runners` from `.cursor/rules/pstack-models.mdc` when present. Otherwise default to one each on `claude-fable-5-1-thinking-max`, `gpt-5.6-sol-max`, `grok-4.6-fast-xhigh`, `claude-opus-5-thinking-xhigh`. Spawn more when the arena covers multiple design directions. Same model N times when the work is generation-bound rather than judgment-sensitive.
 4. Assign output paths. Each candidate writes to its own location (a git worktree where possible, otherwise `/tmp/arena-<slug>/candidate-<n>/`). N candidates writing to the same path is shared mutable state and fails the the **separate-before-serializing-shared-state** principle skill test.
 
 ## Phase B: Fan out
@@ -38,7 +38,7 @@ If a candidate fails to produce output, proceed with N-1 and note the dropout in
 
 ## Phase C: Cross-judge
 
-After all Phase B candidates complete, choose one model from the `arena cross-judge pool` in `~/.cursor/rules/pstack-models.mdc` when present. Otherwise use `claude-fable-5-1-thinking-max`, `gpt-5.6-sol-max`, `grok-4.6-fast-xhigh`, `claude-opus-5-thinking-xhigh`. Prefer a different model family from the parent's. Spawn one readonly judge subagent on that model. It sees the rubric and the candidates by path label, scores each criterion, and recommends a base with rationale. It runs in parallel with the parent's reading in Phase D, not with the candidates themselves. Spawning while candidates are still writing means the judge sees partial or empty outputs and reports them as dropouts.
+After all Phase B candidates complete, choose one model from the `arena cross-judge pool` in `.cursor/rules/pstack-models.mdc` when present. Otherwise use `claude-fable-5-1-thinking-max`, `gpt-5.6-sol-max`, `grok-4.6-fast-xhigh`, `claude-opus-5-thinking-xhigh`. Prefer a different model family from the parent's. Spawn one readonly judge subagent on that model. It sees the rubric and the candidates by path label, scores each criterion, and recommends a base with rationale. It runs in parallel with the parent's reading in Phase D, not with the candidates themselves. Spawning while candidates are still writing means the judge sees partial or empty outputs and reports them as dropouts.
 
 ## Phase D: Pick a base
 

--- a/pstack/skills/interrogate/SKILL.md
+++ b/pstack/skills/interrogate/SKILL.md
@@ -33,7 +33,7 @@ Write one clear paragraph. Reviewers challenge whether the work achieves the int
 
 ## Step 3, Spawn Reviewers
 
-Launch all reviewers in a single message using the Task tool. Use the `interrogate reviewers` list from `~/.cursor/rules/pstack-models.mdc` when present, one reviewer per entry, extending or shrinking the Reviewer A/B/C/D labels below to the configured entry count; otherwise use the table defaults.
+Launch all reviewers in a single message using the Task tool. Use the `interrogate reviewers` list from `.cursor/rules/pstack-models.mdc` when present, one reviewer per entry, extending or shrinking the Reviewer A/B/C/D labels below to the configured entry count; otherwise use the table defaults.
 
 | Subagent | Default model |
 |----------|---------------|

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -5,7 +5,7 @@ description: Configure which models pstack uses per role. Detects your available
 
 # Setup pstack
 
-Write `~/.cursor/rules/pstack-models.mdc`, an always-applied rule that sets pstack's model per role. The skills read it and fall back to their inline defaults when a line is absent, so this is an override layer, not a requirement.
+Write `.cursor/rules/pstack-models.mdc` in the workspace repo. It is an always-applied rule that sets pstack's model per role. The skills read it and fall back to their inline defaults when a line is absent, so this is an override layer, not a requirement. Do not write this rule under the home `.cursor` directory. That copy dies with the cloud agent VM.
 
 ## Steps
 
@@ -15,7 +15,7 @@ Enumerate the model slugs you can pass to a `Task` subagent in this session; tha
 
 ### 2. Load current state
 
-The default role-to-model mapping is the rule shape shown in step 5 below. If `~/.cursor/rules/pstack-models.mdc` already exists, read it and treat its values as the current choices. Otherwise start from those defaults.
+The default role-to-model mapping is the rule shape shown in step 5 below. If `.cursor/rules/pstack-models.mdc` already exists, read it and treat its values as the current choices. If it does not, and a leftover rule exists under the home `.cursor/rules` directory, read that as the current choices. Otherwise start from those defaults.
 
 ### 3. Map and confirm
 
@@ -27,7 +27,7 @@ Every real slug written must be in the detected set; `inherit-parent` and `auto`
 
 ### 5. Write the rule
 
-Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true` and one line per role, using the same labels poteto-mode uses. Overwrite the whole file so re-runs stay idempotent. Shape:
+Write `.cursor/rules/pstack-models.mdc` with `alwaysApply: true` and one line per role, using the same labels poteto-mode uses. Create `.cursor/rules` if it is missing. Overwrite the whole file so re-runs stay idempotent. Shape:
 
 ```
 ---
@@ -58,7 +58,7 @@ interrogate reviewers: claude-fable-5-1-thinking-max, gpt-5.6-sol-max, grok-4.6-
 
 ### 6. Confirm
 
-Tell the user the rule was written and that it applies to new sessions. Re-running this skill updates it.
+Tell the user the rule was written to `.cursor/rules/pstack-models.mdc`. It applies to new sessions, including cloud agents, once the file is committed. Do not gitignore it. Re-running this skill updates it.
 
 ### 7. Offer a verification skill (optional)
 

--- a/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
+++ b/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
@@ -4,7 +4,7 @@ set -eu
 root=$(git rev-parse --show-toplevel)
 cd "$root"
 
-forbidden=$(printf '%s%s' '~/' '.cursor/rules/pstack-models.mdc')
+forbidden='~/.cursor/rules/pstack-models.mdc'
 required='.cursor/rules/pstack-models.mdc'
 
 if git grep -n -F -- "$forbidden" -- pstack ':!pstack/skills/setup-pstack/scripts/*'

--- a/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
+++ b/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
@@ -7,7 +7,7 @@ cd "$root"
 forbidden='~/.cursor/rules/pstack-models.mdc'
 required='.cursor/rules/pstack-models.mdc'
 
-if git grep -n -F -- "$forbidden" -- pstack ':!pstack/skills/setup-pstack/scripts/*'
+if git grep -n -F -- "$forbidden" -- pstack ':!pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh'
 then
   printf '%s\n' "pstack-models must live at $required, not the home path" >&2
   exit 1

--- a/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
+++ b/pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+
+forbidden=$(printf '%s%s' '~/' '.cursor/rules/pstack-models.mdc')
+required='.cursor/rules/pstack-models.mdc'
+
+if git grep -n -F -- "$forbidden" -- pstack ':!pstack/skills/setup-pstack/scripts/*'
+then
+  printf '%s\n' "pstack-models must live at $required, not the home path" >&2
+  exit 1
+fi
+
+if ! git grep -q -F -- "$required" -- pstack/skills/setup-pstack/SKILL.md
+then
+  printf '%s\n' "setup-pstack must write $required" >&2
+  exit 1
+fi
+
+for reader in \
+  pstack/skills/arena/SKILL.md \
+  pstack/skills/swarm/SKILL.md \
+  pstack/skills/interrogate/SKILL.md \
+  pstack/docs/guide/01-setup.md \
+  pstack/README.md
+do
+  if ! git grep -q -F -- "$required" -- "$reader"
+  then
+    printf '%s\n' "$reader must name $required" >&2
+    exit 1
+  fi
+done

--- a/pstack/skills/swarm/SKILL.md
+++ b/pstack/skills/swarm/SKILL.md
@@ -22,7 +22,7 @@ Open a todolist with one entry per phase before launching anything.
 1. State the done predicate and the artifact or report the swarm must return.
 2. Choose the shape. Partition into slices, race N workers on identical briefs, or mix both. For a race or mixed shape, declare `first pass`, `rank all`, or `best-of` before spawning.
 3. Set N from the user or derive it from the shape. N is total workers, not the cloud concurrency limit.
-4. Pick the worker model from `swarm workers` in `~/.cursor/rules/pstack-models.mdc` when present. Otherwise use `grok-4.6-fast-xhigh`. For a model race, name each arm's model up front.
+4. Pick the worker model from `swarm workers` in `.cursor/rules/pstack-models.mdc` when present. Otherwise use `grok-4.6-fast-xhigh`. For a model race, name each arm's model up front.
 5. Give each worker its own writable output when it writes. Use a worktree, branch, or `/tmp/swarm-<slug>/worker-<n>/`.
 
 ## Phase B: Fan out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`/setup-pstack` wrote `~/.cursor/rules/pstack-models.mdc`. A cloud agent VM throws that home directory away. The next cloud agent never sees the mapping.

The file has to live in the workspace at `.cursor/rules/pstack-models.mdc`. Cursor already loads repo rules for cloud agents. Skills that Read the file find it there too.

## Scope

`pstack/skills/setup-pstack/SKILL.md` writes `.cursor/rules/pstack-models.mdc`. It seeds from a leftover home rule when the repo file is missing. It tells the user to commit the file and not gitignore it.

`arena`, `swarm`, and `interrogate` read the same repo path.

`pstack/docs/guide/01-setup.md` and `pstack/README.md` name the new path.

`pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh` fails if the home path returns.

## Tradeoffs

Setup still reads a leftover home rule once, then writes only the repo file. Readers do not keep a dual path. People who already have a home file need to re-run `/setup-pstack` or copy the file into the repo.

The mapping is now per repo, not user-global. That is the point for cloud agents. Desktop users who wanted one mapping across every project now keep it in each repo.

## Blast Radius

Any agent that runs `/setup-pstack` or reads the rule path. Skills that only say "configured via /setup-pstack" keep working because `alwaysApply: true` still injects the rule once it is in the repo.

No runtime application code.

## Verification

Ran `pstack/skills/setup-pstack/scripts/check-pstack-models-path.sh` before the retarget. It printed every home-path hit and exited 1.

Ran the same script after the retarget. Exit 0. `git grep` finds no home-path contract under skills or docs.

Wrote a dummy rule to a temp workspace `.cursor/rules/pstack-models.mdc`. The home file stayed absent.

Comment Sicko found no comments. It flagged the check's hidden needle. The script now names the home path as a literal and excludes its own directory.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7e2d458-8c5b-42cf-ae01-e39ab04e40f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7e2d458-8c5b-42cf-ae01-e39ab04e40f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
