### PR TITLE
pstack: link the oh-my-pi community port

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -246,6 +246,8 @@ type [`/automate-me`](./skills/automate-me/SKILL.md). it mines your recent trans
 
 models are configurable too. type [`/setup-pstack`](./skills/setup-pstack/SKILL.md). it detects the models you have access to and writes a small always-applied rule mapping each role (code, judgment, the review panels) to a model. every skill reads it and falls back to sensible defaults when the rule is absent, so you override only what you want.
 
+pstack is cursor-first, but the skills are mostly portable prose. there's a community port for [oh-my-pi](https://github.com/can1357/oh-my-pi) at [negoro26/pstack-omp](https://github.com/negoro26/pstack-omp), installed as an omp marketplace. it swaps cursor mechanics for omp ones and names model capabilities instead of vendor slugs.
+
 ## automations
 
 pstack also ships a dormant [benny automation pack](./automations/benny/). benny triages slack issue reports, then reproduces and fixes confirmed bugs with real ui evidence. its files are not registered as slash skills.


### PR DESCRIPTION
Adds one paragraph under **make it yours** pointing at a community port of pstack for [oh-my-pi](https://github.com/can1357/oh-my-pi): [negoro26/pstack-omp](https://github.com/negoro26/pstack-omp).

The README already says "fork it. improve it. make it yours." This gives readers on a different harness a place to go.

What the port is: all 45 skills, 23 playbooks, and both agents at `7314f72`, with cursor mechanics swapped for omp equivalents (cloud agents to isolated subagents, `/loop` to a supervised watcher, transcript paths, and so on) and every vendor model slug replaced with a capability name the operator binds once. It ships as an omp marketplace and installs with two commands. Nothing in this PR changes pstack itself.

Happy to move the line elsewhere or drop it if you'd rather not link out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only outbound links; no code, config, or data-handling behavior changes.
> 
> **Overview**
> Adds a short note in **make it yours** that pstack stays Cursor-first while the skill prose is largely portable, and points readers to the community [oh-my-pi](https://github.com/can1357/oh-my-pi) marketplace port [negoro26/pstack-omp](https://github.com/negoro26/pstack-omp).
> 
> The new paragraph explains that install is via an omp marketplace and that the port replaces Cursor-specific mechanics with omp equivalents and capability-based model naming instead of vendor slugs. No runtime, skill, or automation files change—only `pstack/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97a4f1114aab235e75c46e56ece687d905789bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->