### PR TITLE
chore(pstack): bump to 0.15.0 and sync README/docs counts

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.14.8",
+	"version": "0.15.0",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/README.md
+++ b/pstack/README.md
@@ -35,7 +35,7 @@ use [`/poteto-mode`](./skills/poteto-mode/SKILL.md) at the start of a task. it r
 
 ### just use [`/poteto-mode`](./skills/poteto-mode/SKILL.md)
 
-this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with twenty-two playbooks:
+this skill is the main shortcut. i use it whenever i need the agent to do rigorous engineering work. it comes with twenty-three playbooks:
 
 ```
 /poteto-mode this pr has a subtle bug where the scroll drifts every 750ms even when idle. repro
@@ -48,7 +48,7 @@ morning.
 ```
 
 <details>
-<summary>the twenty-two playbooks</summary>
+<summary>the twenty-three playbooks</summary>
 
 | playbook | for |
 |---|---|
@@ -74,6 +74,7 @@ morning.
 | [pause safely](./skills/poteto-mode/playbooks/pause-safely.md) | suspend in-flight work cleanly so it can be resumed later. |
 | [multi-phase plan](./skills/poteto-mode/playbooks/multi-phase-plan.md) | work that spans phases or stacked PRs. |
 | [worktree cleanup](./skills/poteto-mode/playbooks/worktree-cleanup.md) | reclaim disk by pruning merged or abandoned worktrees and stale ios simulators, safety-gated. |
+| [opening a pr](./skills/poteto-mode/playbooks/opening-a-pr.md) | open a ready pr from small ordered commits with a conventional commits title and a briefing-style body. invoked at the end of every other playbook. |
 
 </details>
 

--- a/pstack/docs/guide/02-poteto-mode.md
+++ b/pstack/docs/guide/02-poteto-mode.md
@@ -1,6 +1,6 @@
 # Route work through `/poteto-mode`
 
-`/poteto-mode` is the front door. You give it a goal, it matches one of twenty-two playbooks, copies that playbook's steps into the todo list, and calls the other skills as the steps need them. In this page you learn what a good prompt looks like, and how little of one you actually need.
+`/poteto-mode` is the front door. You give it a goal, it matches one of twenty-three playbooks, copies that playbook's steps into the todo list, and calls the other skills as the steps need them. In this page you learn what a good prompt looks like, and how little of one you actually need.
 
 ![A dispatcher pulls a switch lever to route robots on rail handcars toward lit gates, under a /poteto-mode departure board listing BUG FIX, FEATURE, and INVESTIGATION.](./images/router.jpg)
 

--- a/pstack/docs/guide/08-principles.md
+++ b/pstack/docs/guide/08-principles.md
@@ -26,7 +26,7 @@ separate before serializing shared state. give each attempt its own worktree, no
 
 Each phrase lands because the rule behind it is specific. The agent still has to say, in its reply, which decision the rule changed. A principle citation with no decision behind it is the tell that it name-dropped instead of applying.
 
-## The 21, briefly
+## The 23, briefly
 
 The core principles decide how much to build and when to rethink the design:
 

--- a/pstack/docs/guide/README.md
+++ b/pstack/docs/guide/README.md
@@ -11,7 +11,7 @@ Here's what you'll learn:
 5. [Build and clean the change](./05-build-and-clean.md). The build playbooks, `/tdd`, `/unslop`, and `/no-comments`.
 6. [Verify and ship](./06-verify-and-ship.md). Prove behavior on the real app, then open a focused PR and drive it to merged.
 7. [Run work while you sleep](./07-overnight.md). An overnight contract, a decision log you can audit, and the playbooks that scale past one agent.
-8. [Steer with principle names](./08-principles.md). The 21 names that redirect an agent mid-task.
+8. [Steer with principle names](./08-principles.md). The 23 names that redirect an agent mid-task.
 9. [Make it yours](./09-make-it-yours.md). Your own mode, plus how to test a skill change.
 10. [Recipes and pitfalls](./10-recipes-and-pitfalls.md). Prompts to copy and mistakes to skip.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The pstack tree on main ships 23 principle skills and 23 playbooks. The README and the guide still carried counts from before `principle-attack-the-premise`, `principle-encode-lessons-in-structure`, and the `opening-a-pr` playbook landed, and the README playbook table had no row for `opening-a-pr`. This release bumps the plugin version and brings the counts and tables back in line with the tree. No feature ports.

## Scope

- `pstack/.cursor-plugin/plugin.json`. Version `0.14.8` → `0.15.0`. This is the only version string in the repo that tracks the plugin.
- `pstack/README.md`. "twenty-two playbooks" → "twenty-three" in the intro line and the `<details>` summary. New `opening a pr` row at the end of the playbook table, in the same order as `skills/poteto-mode/SKILL.md`.
- `pstack/docs/guide/02-poteto-mode.md`. "one of twenty-two playbooks" → "twenty-three".
- `pstack/docs/guide/README.md`. "The 21 names" → "The 23 names".
- `pstack/docs/guide/08-principles.md`. Heading "The 21, briefly" → "The 23, briefly". The body already listed 23.

Out of scope: new skills, everysphere ports, logo changes, prose rewrites, version bumps elsewhere in the monorepo. The README principles section already said twenty-three and is unchanged.

## Verification

- `rg -n 'twenty-two|The 21|21 names|## The 21' pstack/README.md pstack/docs/guide pstack/skills/poteto-mode/SKILL.md` returns no hits.
- README playbook table rows, `SKILL.md` playbook entries, and `playbooks/*.md` files all count 23, and every playbook file has a row and an entry.
- README principle rows, guide 08 bullets, `SKILL.md` principle entries, and `skills/principle-*` directories all count 23, and every principle directory is linked from both.
- All 24 non-principle skills under `skills/*/SKILL.md` appear in the README skills table.
- Every relative link in `README.md` and `docs/guide/*.md` resolves to a file.
- `node scripts/validate-plugins.mjs` passes, as CI runs it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-854ad5c1-97c4-4d90-997c-cc2009626a18?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-854ad5c1-97c4-4d90-997c-cc2009626a18&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

