### PR TITLE
pstack: every claim carries its evidence or its label

### DIFF
--- a/pstack/.cursor-plugin/plugin.json
+++ b/pstack/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "pstack",
 	"displayName": "pstack",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"description": "if you want to go fast, go deep first. pstack helps you write less, but higher quality code. rigorous agent workflows you can parallelize with confidence.",
 	"author": {
 		"name": "Lauren Tan"

--- a/pstack/skills/poteto-mode/SKILL.md
+++ b/pstack/skills/poteto-mode/SKILL.md
@@ -104,6 +104,7 @@ Write the reply clean as you draft it. A cleanup pass after drafting does not re
 - **Terse is not an excuse to drop content.** Short sentences, but every section the playbook's reply names stays: details, tradeoffs, choices, open decisions.
 - **Frame impact for the consumer and the maintainer.** Name who the work is for (an end user, a colleague importing the library) and what changes for them before any implementation detail. Then what the next engineer who owns this code inherits. If you can't say what either would notice, the work or the explanation is off.
 - **Never fabricate a link, citation, or transcript reference.** Link only artifacts you produced or read this session.
+- **Every claim carries its evidence or its label in the same sentence.** Measured, inferred, or guess. A prediction or an unseen cause is a guess. Never hand the human a check you could run.
 
 Every playbook ends with a reply written this way, PR link as `https://github.com/<owner>/<repo>/pull/<number>`. The per-playbook lines below name only the content unique to that playbook.
 


### PR DESCRIPTION
## Why

Agents state predictions and unseen causes as fact. In an eval on an investigation task with a downed tool, the baseline did it in 10 of 10 runs. With this bullet the affected paragraph carried a label in 30 of 30 runs and the bare cause fell to 0 of 5, at 44 tokens.

## Scope

One bullet in the mode skill's reply rules.
Patch version bump in `pstack/.cursor-plugin/plugin.json`, 0.15.0 to 0.15.1.

## Tradeoffs

The line does not stop a bare restatement of a labeled prediction in a summary; that residual is known.

## Blast radius

Prose only, one line, loaded by every session.

## Verification

130 eval runs across four arms, a hillclimb, and a post-merge probe under real invocation, 5 of 5 replies carrying labels against 0 of 5 without the line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent reply guidelines; affects prose behavior across sessions, not application code or security paths.
> 
> **Overview**
> Adds a **Writing the reply** rule in Poteto mode so agents must attach **evidence or an epistemic label** (measured, inferred, or guess) to every claim in the same sentence, and must not punt verification to the human when they could run the check themselves.
> 
> **Impact for anyone using Poteto mode:** replies should read less like bare speculation on causes and predictions; labeled uncertainty is explicit instead of stated as fact. **For maintainers:** one more prose constraint alongside the existing unslop and no-fabrication bullets; no runtime or API changes.
> 
> The PR description notes eval gains on investigation-style tasks and a known residual where a labeled prediction can still be restated without fresh evidence in summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa35bbb2836b1d5f33cca59da3f63cc34f6ad914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
