### PR TITLE
docs: add Outlook, Outlook Calendar, and OneDrive to the plugin table

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `hunter` | [Hunter](third_party/hunter/) | Cursor | Integrations | Find and verify emails, discover companies, and save leads. |
 | `gamma` | [Gamma](third_party/gamma/) | Cursor | Integrations | Generate presentations, documents, and webpages. |
 | `teams` | [Teams](third_party/teams/) | Cursor | Productivity | Search, read, and send Microsoft Teams chats and channel messages. |
+| `outlook` | [Outlook](third_party/outlook/) | Cursor | Productivity | Search, read, and send Microsoft Outlook email, and look up contacts. |
+| `outlook-calendar` | [Outlook Calendar](third_party/outlook-calendar/) | Cursor | Productivity | List, create, update, and cancel Microsoft Outlook calendar events. |
+| `onedrive` | [OneDrive](third_party/onedrive/) | Cursor | Productivity | Browse, search, and read Microsoft OneDrive files. |
 Author values match each plugin’s `plugin.json` `author.name` (Cursor lists `plugins@cursor.com` in the manifest).
 
 ## Repository structure


### PR DESCRIPTION
The README table lists 67 plugins while `.cursor-plugin/marketplace.json` lists 70. Outlook, Outlook Calendar, and OneDrive were added in #276 without table rows, so they are not discoverable from the README.

Adds the three rows in the existing format, with name, author, category, and description taken from each plugin's `plugin.json`.

Verified:
- `node scripts/validate-plugins.mjs` passes.
- README table names, paths, and descriptions now match `marketplace.json` exactly (70/70).

The validate workflow only triggers on `marketplace.json`, `**/plugin.json`, and `schemas/**`, so no CI checks run for this README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation update with no code or manifest changes.
> 
> **Overview**
> Adds three missing **Productivity** plugin rows to the README plugins table so it matches `.cursor-plugin/marketplace.json` (70 plugins): **`outlook`**, **`outlook-calendar`**, and **`onedrive`**, placed after **`teams`**, with names, paths, and descriptions aligned to each plugin’s `plugin.json`.
> 
> No runtime, manifest, or validation script changes—documentation discoverability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802d5c30508559b2e5dbc61ece81591c064a724e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->