### PR TITLE
Add an empty Finance plugin that mirrors the Grok connector

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -339,6 +339,16 @@
       "description": "Search, read, and send Microsoft Teams chats and channel messages."
     },
     {
+      "name": "finance",
+      "source": "third_party/finance",
+      "description": "Securely connect your accounts so Grok can help with questions about your spending, subscriptions, balances, and investments.",
+      "minClientVersions": {
+        "cursor": "never",
+        "grokbot": "0.49.0",
+        "sand": "0.49.0"
+      }
+    },
+    {
       "name": "x-ads",
       "source": "third_party/x-ads",
       "description": "Manage ad campaigns, create ads, track conversions, and pull performance stats."

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Official Cursor plugins for popular developer tools, frameworks, and SaaS produc
 | `hunter` | [Hunter](third_party/hunter/) | Cursor | Integrations | Find and verify emails, discover companies, and save leads. |
 | `gamma` | [Gamma](third_party/gamma/) | Cursor | Integrations | Generate presentations, documents, and webpages. |
 | `teams` | [Teams](third_party/teams/) | Cursor | Productivity | Search, read, and send Microsoft Teams chats and channel messages. |
+| `finance` | [Finance](third_party/finance/) | Cursor | Integrations | Securely connect your accounts so Grok can help with questions about your spending, subscriptions, balances, and investments. |
 Author values match each plugin’s `plugin.json` `author.name` (Cursor lists `plugins@cursor.com` in the manifest).
 
 ## Repository structure

--- a/schemas/marketplace.schema.json
+++ b/schemas/marketplace.schema.json
@@ -82,14 +82,29 @@
       "minProperties": 1,
       "properties": {
         "cursor": {
-          "$ref": "#/$defs/semver",
-          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\")."
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\"), or \"never\" to hide it from Cursor entirely."
+        },
+        "grokbot": {
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Minimum Grok Bot version required to install the plugin (e.g. \"0.49.0\"), or \"never\" to hide it from Grok Bot entirely."
+        },
+        "sand": {
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Deprecated client id for Grok Bot. Same meaning as grokbot."
         }
       },
       "additionalProperties": {
-        "$ref": "#/$defs/semver",
-        "description": "Minimum version required for another client identifier."
+        "$ref": "#/$defs/clientVersionRequirement",
+        "description": "Minimum version required for another client identifier, or \"never\" to hide the plugin from that client."
       }
+    },
+    "clientVersionRequirement": {
+      "description": "A minimum semantic version, or the literal \"never\" when that client must not list or install the plugin.",
+      "oneOf": [
+        { "$ref": "#/$defs/semver" },
+        { "const": "never" }
+      ]
     },
     "semver": {
       "type": "string",

--- a/schemas/plugin.schema.json
+++ b/schemas/plugin.schema.json
@@ -139,14 +139,29 @@
       "minProperties": 1,
       "properties": {
         "cursor": {
-          "$ref": "#/$defs/semver",
-          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\")."
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Minimum Cursor version required to install the plugin (e.g. \"3.13.0\"), or \"never\" to hide it from Cursor entirely."
+        },
+        "grokbot": {
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Minimum Grok Bot version required to install the plugin (e.g. \"0.49.0\"), or \"never\" to hide it from Grok Bot entirely."
+        },
+        "sand": {
+          "$ref": "#/$defs/clientVersionRequirement",
+          "description": "Deprecated client id for Grok Bot. Same meaning as grokbot."
         }
       },
       "additionalProperties": {
-        "$ref": "#/$defs/semver",
-        "description": "Minimum version required for another client identifier."
+        "$ref": "#/$defs/clientVersionRequirement",
+        "description": "Minimum version required for another client identifier, or \"never\" to hide the plugin from that client."
       }
+    },
+    "clientVersionRequirement": {
+      "description": "A minimum semantic version, or the literal \"never\" when that client must not list or install the plugin.",
+      "oneOf": [
+        { "$ref": "#/$defs/semver" },
+        { "const": "never" }
+      ]
     },
     "semver": {
       "type": "string",

--- a/third_party/finance/.cursor-plugin/plugin.json
+++ b/third_party/finance/.cursor-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "finance",
+  "displayName": "Finance",
+  "version": "1.0.0",
+  "minClientVersions": {
+    "cursor": "never",
+    "grokbot": "0.49.0",
+    "sand": "0.49.0"
+  },
+  "description": "Securely connect your accounts so Grok can help with questions about your spending, subscriptions, balances, and investments.",
+  "author": {
+    "name": "Cursor",
+    "email": "plugins@cursor.com"
+  },
+  "homepage": "https://grok.com/connectors",
+  "repository": "https://github.com/cursor/plugins",
+  "license": "MIT",
+  "logo": "assets/logo.svg",
+  "keywords": [
+    "finance",
+    "accounts",
+    "spending",
+    "subscriptions",
+    "balances",
+    "investments",
+    "grok"
+  ],
+  "category": "integrations",
+  "tags": [
+    "finance",
+    "accounts",
+    "grok"
+  ]
+}

--- a/third_party/finance/CHANGELOG.md
+++ b/third_party/finance/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this plugin will be documented here.
+
+## 1.0.0 — initial release
+
+- Added an empty Finance marketplace card that mirrors the Grok Finance connector.
+- No skills and no connector are bundled. The Cursor backend handles this plugin.
+- Requires Grok Bot 0.49 or newer, and is never allowed in Cursor.

--- a/third_party/finance/LICENSE
+++ b/third_party/finance/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Cursor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/finance/README.md
+++ b/third_party/finance/README.md
@@ -1,0 +1,24 @@
+# Finance
+
+Marketplace mirror of the Grok **Finance** connector.
+
+Securely connect your accounts so Grok can help with questions about your spending, subscriptions, balances, and investments.
+
+This plugin is empty on purpose. It has no skills and no connector of its own. The Cursor backend handles this plugin specially and talks to the Finance connector there.
+
+## Who can use it
+
+- Grok Bot **0.49** or newer.
+- Not available in Cursor. Cursor must not list or install this plugin.
+
+## About this connector
+
+- **See your finances in chat.** Ask about balances, recent spending, subscriptions, and investments across linked accounts.
+- **Your credentials stay private.** xAI does not store or view any bank account or password credentials.
+- **Read-only access.** A financial connection is read-only, which means it can't be used to move money into or out of bank accounts.
+
+Third-party connectors are not built or maintained by xAI. Use caution when granting access to external services. Review the permissions before connecting. Usage is subject to the [xAI Privacy Policy](https://x.ai/legal/privacy-policy).
+
+## License
+
+MIT

--- a/third_party/finance/assets/logo.svg
+++ b/third_party/finance/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" fill="none" viewBox="0 0 192 192">
+  <rect width="192" height="192" fill="#fff"/>
+  <g fill="none" stroke="#14804A" stroke-width="7" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M40 82 96 42l56 40"/>
+    <path d="M34 82h124"/>
+    <path d="M54 90v48"/>
+    <path d="M96 90v48"/>
+    <path d="M138 90v48"/>
+    <path d="M42 138h108"/>
+    <path d="M34 150h124"/>
+    <path d="M28 162h136"/>
+  </g>
+</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a Finance marketplace card that mirrors the Grok Finance connector.
- The plugin is empty on purpose: no skills and no connector. The Cursor backend handles this plugin specially.
- Requires Grok Bot 0.49 or newer (`grokbot` and the older `sand` client id are both set to `0.49.0`).
- Never allowed in Cursor: `minClientVersions.cursor` is `"never"`. Cursor must not list or install it.

## Notes

- Copy matches the Grok Finance connector card: spending, subscriptions, balances, and investments, with private credentials and read-only access.
- `"never"` is now a valid `minClientVersions` value. Treat it as a hard deny, not as a version to compare.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69a5212e-67ad-4848-af8a-44a1bfeaf9aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69a5212e-67ad-4848-af8a-44a1bfeaf9aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

