### PR TITLE
feat(pstack): setup-pstack budget ask (max/xhigh/high/medium)

### DIFF
--- a/pstack/README.md
+++ b/pstack/README.md
@@ -22,7 +22,7 @@ fork it. improve it. make it yours. PRs are welcome!
 
 two steps:
 
-1. run [`/setup-pstack`](./skills/setup-pstack/SKILL.md) and choose which models you want.
+1. run [`/setup-pstack`](./skills/setup-pstack/SKILL.md), pick a reasoning budget, and choose which models you want.
 2. use [`/poteto-mode`](./skills/poteto-mode/SKILL.md) whenever you're doing anything that requires rigor.
 
 new here? the [pstack guide](./docs/guide/README.md) walks you through a first real task, from setup and prompting through verification and overnight runs.

--- a/pstack/docs/guide/01-setup.md
+++ b/pstack/docs/guide/01-setup.md
@@ -20,7 +20,7 @@ Run:
 /setup-pstack
 ```
 
-[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, shows you each role (code delegates, judgment, the review panels), and asks what you want. Answer the questions. It writes `~/.cursor/rules/pstack-models.mdc`, a small rule every pstack skill reads.
+[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, asks for a reasoning budget (unlimited, large, medium, or small), shows you each role (code delegates, judgment, the review panels) at that budget, and asks what you want. Answer the questions. It writes `~/.cursor/rules/pstack-models.mdc`, a small rule every pstack skill reads.
 
 You only override what you care about. A role with no line in the rule keeps the skill's default. To restore a default later, delete that role's line, or just run `/setup-pstack` again.
 

--- a/pstack/docs/guide/01-setup.md
+++ b/pstack/docs/guide/01-setup.md
@@ -20,7 +20,7 @@ Run:
 /setup-pstack
 ```
 
-[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, asks for a reasoning budget (unlimited, large, medium, or small), shows you each role (code delegates, judgment, the review panels) at that budget, and asks what you want. Answer the questions. It writes `~/.cursor/rules/pstack-models.mdc`, a small rule every pstack skill reads.
+[`/setup-pstack`](../../skills/setup-pstack/SKILL.md) detects the models you have access to, asks for a reasoning budget, shows you each role (code delegates, judgment, the review panels), and asks what you want. Answer the questions. It writes `~/.cursor/rules/pstack-models.mdc`, a small rule every pstack skill reads.
 
 You only override what you care about. A role with no line in the rule keeps the skill's default. To restore a default later, delete that role's line, or just run `/setup-pstack` again.
 

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: setup-pstack
-description: Configure which models pstack uses per role and how much reasoning effort they get. Detects your available models, asks for a budget, and writes an always-applied rule that overrides the skill defaults. Use for /setup-pstack, "configure pstack models", "pstack budget", or changing pstack's model choices.
+description: Configure which models pstack uses per role and at what reasoning budget. Detects your available models and writes an always-applied rule that overrides the skill defaults. Use for /setup-pstack, "configure pstack models", "pstack budget", or changing pstack's model choices.
 ---
 
 # Setup pstack
 
-Write `~/.cursor/rules/pstack-models.mdc`, an always-applied rule that sets pstack's model per role. A budget sets the reasoning effort for every role at once. You can then change any single role.
+Write `~/.cursor/rules/pstack-models.mdc`, an always-applied rule that sets pstack's model per role.
 
 ## Steps
 
@@ -19,31 +19,16 @@ The default role-to-model mapping is the rule shape shown in step 5 below. If `~
 
 ### 3. Budget, map, and confirm
 
-Work in this order.
-
-**(a) Ask for a budget.** Prefer AskQuestion over free text. Offer these four options, in this order and with these exact labels. When the current rule records a budget, name it in the question as the current one.
+**(a) Ask for a budget.** Prefer AskQuestion over free text. Offer these four options with these exact labels, and name the current budget when the rule records one.
 
 - `unlimited — keep max`
 - `large — xhigh reasoning`
 - `medium — high reasoning`
 - `small — medium reasoning`
 
-The budget sets one target effort for every real slug. `unlimited` keeps each slug at the effort it has. `large` targets `xhigh`, `medium` targets `high`, and `small` targets `medium`.
+**(b) Apply it.** `unlimited` changes nothing. `large`, `medium`, and `small` set the effort token of every real slug, panel entries included, to `xhigh`, `high`, or `medium`. The effort token is the last token, or the one before a trailing `fast`, on the ladder `max` > `xhigh` > `high` > `medium` > `low`. If the result is not a detected slug, use the same family's detected slug with the highest effort at or below the target, else mark the role as needing a choice. `inherit-parent` and `auto` do not change. So `small` turns `claude-fable-5-1-thinking-max` into `claude-fable-5-1-thinking-medium`, and `grok-4.6-fast-xhigh` into `cursor-grok-4.6-medium-fast` when only that form is detected. On a re-run, rebuild from the defaults, keep any role you changed by family or list, and apply the budget to all of it.
 
-**(b) Apply the budget.** Build the working table from the skill defaults. On a re-run, a role whose current value differs from the default in more than effort tokens (a different family, an alias, or a different list) is your earlier choice, so carry it over. Then rewrite every real slug in the table, each entry of a panel list on its own.
-
-The effort ladder is `max` > `xhigh` > `high` > `medium` > `low`. The effort token is the last token of a slug, or the token before a trailing `fast`. Replace it with the target. The rest of the slug is the family. It includes flags such as `thinking` and `fast`, and it does not change. A `cursor-` prefix and the position of `fast` do not change the family, so `grok-4.6-fast-xhigh` and `cursor-grok-4.6-xhigh-fast` are one family. If the rewritten slug is not in the detected set, use the detected slug of the same family with the highest effort at or below the target. If the family has no detected slug at or below the target, keep the slug and mark the role as needing a choice. `inherit-parent`, `auto`, and a slug with no effort token do not change. The budget sets the effort rather than capping it, so a re-run with a larger budget raises the table and a re-run with a smaller budget lowers it.
-
-| default and `unlimited` | `large` | `medium` | `small` |
-|---|---|---|---|
-| `claude-fable-5-1-thinking-max` | `claude-fable-5-1-thinking-xhigh` | `claude-fable-5-1-thinking-high` | `claude-fable-5-1-thinking-medium` |
-| `grok-4.6-fast-xhigh` | `grok-4.6-fast-xhigh` | `grok-4.6-fast-high` | `grok-4.6-fast-medium` |
-| `gpt-5.6-sol-max` | `gpt-5.6-sol-xhigh` | `gpt-5.6-sol-high` | `gpt-5.6-sol-medium` |
-| `claude-opus-5-thinking-xhigh` | `claude-opus-5-thinking-xhigh` | `claude-opus-5-thinking-high` | `claude-opus-5-thinking-medium` |
-
-When only the `cursor-grok-4.6-<effort>-fast` form is detected, the grok row lands on `cursor-grok-4.6-xhigh-fast`, `cursor-grok-4.6-high-fast`, and `cursor-grok-4.6-medium-fast`. When a family skips a tier, the next detected tier down applies. A `gpt-5.6-sol` set with only `max` and `medium` gives `gpt-5.6-sol-medium` for `large`, `medium`, and `small`.
-
-**(c) Show the roles and confirm.** Show every role with its model from the working table, marking any real slug not in the detected set as needing a choice. Ask whether to accept as-is or change specific roles, offering the detected models plus `inherit-parent` and `auto` (both mean: this role runs on the parent chat model, which is how Auto users stay on Auto) as the options. Prefer AskQuestion over free text. A model you pick here is written as you pick it, with no budget rewrite. For panel roles (arena runners, architect runners, interrogate reviewers) the value is a list, and one subagent runs per entry, alias entries included, so the list length sets the count. `arena cross-judge pool` is also a list, but Arena selects one value from it whose model family differs from the parent's when possible. `swarm workers` is the default model for every worker unless a race or comparison assigns another model per arm.
+**(c) Show the roles and confirm.** Show every role with its model, marking any real slug not in the detected set as needing a choice. Ask whether to accept as-is or change specific roles, offering the detected models plus `inherit-parent` and `auto` (both mean: this role runs on the parent chat model, which is how Auto users stay on Auto) as the options. Prefer AskQuestion over free text. For panel roles (arena runners, architect runners, interrogate reviewers) the value is a list, and one subagent runs per entry, alias entries included, so the list length sets the count. `arena cross-judge pool` is also a list, but Arena selects one value from it whose model family differs from the parent's when possible. `swarm workers` is the default model for every worker unless a race or comparison assigns another model per arm.
 
 ### 4. Validate
 
@@ -51,7 +36,7 @@ Every real slug written must be in the detected set. `inherit-parent` and `auto`
 
 ### 5. Write the rule
 
-Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true`, one `# budget` line, and one line per role, using the same labels poteto-mode uses. The `# budget` line records the label you chose and its target effort, so a re-run can show it. Overwrite the whole file so re-runs stay idempotent. Shape:
+Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true`, a `# budget` line, and one line per role, using the same labels poteto-mode uses. Overwrite the whole file so re-runs stay idempotent. Shape:
 
 ```
 ---

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: setup-pstack
-description: Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overrides the skill defaults. Use for /setup-pstack, "configure pstack models", or changing pstack's model choices.
+description: Configure which models pstack uses per role and how much reasoning effort they get. Detects your available models, asks for a budget, and writes an always-applied rule that overrides the skill defaults. Use for /setup-pstack, "configure pstack models", "pstack budget", or changing pstack's model choices.
 ---
 
 # Setup pstack
 
-Write `~/.cursor/rules/pstack-models.mdc`, an always-applied rule that sets pstack's model per role.
+Write `~/.cursor/rules/pstack-models.mdc`, an always-applied rule that sets pstack's model per role. A budget sets the reasoning effort for every role at once. You can then change any single role.
 
 ## Steps
 
@@ -15,11 +15,35 @@ Enumerate the model slugs you can pass to a `Task` subagent in this session. Tha
 
 ### 2. Load current state
 
-The default role-to-model mapping is the rule shape shown in step 5 below. If `~/.cursor/rules/pstack-models.mdc` already exists, read it and treat its values as the current choices. Otherwise start from those defaults.
+The default role-to-model mapping is the rule shape shown in step 5 below. If `~/.cursor/rules/pstack-models.mdc` already exists, read it and treat its `# budget` line and its role values as the current choices. Otherwise start from those defaults.
 
-### 3. Map and confirm
+### 3. Budget, map, and confirm
 
-Show every role with its current model, marking any real slug not in the detected set as needing a choice. Ask whether to accept as-is or change specific roles, offering the detected models plus `inherit-parent` and `auto` (both mean: this role runs on the parent chat model, which is how Auto users stay on Auto) as the options. Prefer AskQuestion over free text. For panel roles (arena runners, architect runners, interrogate reviewers) the value is a list, and one subagent runs per entry, alias entries included, so the list length sets the count. `arena cross-judge pool` is also a list, but Arena selects one value from it whose model family differs from the parent's when possible. `swarm workers` is the default model for every worker unless a race or comparison assigns another model per arm.
+Work in this order.
+
+**(a) Ask for a budget.** Prefer AskQuestion over free text. Offer these four options, in this order and with these exact labels. When the current rule records a budget, name it in the question as the current one.
+
+- `unlimited — keep max`
+- `large — xhigh reasoning`
+- `medium — high reasoning`
+- `small — medium reasoning`
+
+The budget sets one target effort for every real slug. `unlimited` keeps each slug at the effort it has. `large` targets `xhigh`, `medium` targets `high`, and `small` targets `medium`.
+
+**(b) Apply the budget.** Build the working table from the skill defaults. On a re-run, a role whose current value differs from the default in more than effort tokens (a different family, an alias, or a different list) is your earlier choice, so carry it over. Then rewrite every real slug in the table, each entry of a panel list on its own.
+
+The effort ladder is `max` > `xhigh` > `high` > `medium` > `low`. The effort token is the last token of a slug, or the token before a trailing `fast`. Replace it with the target. The rest of the slug is the family. It includes flags such as `thinking` and `fast`, and it does not change. A `cursor-` prefix and the position of `fast` do not change the family, so `grok-4.6-fast-xhigh` and `cursor-grok-4.6-xhigh-fast` are one family. If the rewritten slug is not in the detected set, use the detected slug of the same family with the highest effort at or below the target. If the family has no detected slug at or below the target, keep the slug and mark the role as needing a choice. `inherit-parent`, `auto`, and a slug with no effort token do not change. The budget sets the effort rather than capping it, so a re-run with a larger budget raises the table and a re-run with a smaller budget lowers it.
+
+| default and `unlimited` | `large` | `medium` | `small` |
+|---|---|---|---|
+| `claude-fable-5-1-thinking-max` | `claude-fable-5-1-thinking-xhigh` | `claude-fable-5-1-thinking-high` | `claude-fable-5-1-thinking-medium` |
+| `grok-4.6-fast-xhigh` | `grok-4.6-fast-xhigh` | `grok-4.6-fast-high` | `grok-4.6-fast-medium` |
+| `gpt-5.6-sol-max` | `gpt-5.6-sol-xhigh` | `gpt-5.6-sol-high` | `gpt-5.6-sol-medium` |
+| `claude-opus-5-thinking-xhigh` | `claude-opus-5-thinking-xhigh` | `claude-opus-5-thinking-high` | `claude-opus-5-thinking-medium` |
+
+When only the `cursor-grok-4.6-<effort>-fast` form is detected, the grok row lands on `cursor-grok-4.6-xhigh-fast`, `cursor-grok-4.6-high-fast`, and `cursor-grok-4.6-medium-fast`. When a family skips a tier, the next detected tier down applies. A `gpt-5.6-sol` set with only `max` and `medium` gives `gpt-5.6-sol-medium` for `large`, `medium`, and `small`.
+
+**(c) Show the roles and confirm.** Show every role with its model from the working table, marking any real slug not in the detected set as needing a choice. Ask whether to accept as-is or change specific roles, offering the detected models plus `inherit-parent` and `auto` (both mean: this role runs on the parent chat model, which is how Auto users stay on Auto) as the options. Prefer AskQuestion over free text. A model you pick here is written as you pick it, with no budget rewrite. For panel roles (arena runners, architect runners, interrogate reviewers) the value is a list, and one subagent runs per entry, alias entries included, so the list length sets the count. `arena cross-judge pool` is also a list, but Arena selects one value from it whose model family differs from the parent's when possible. `swarm workers` is the default model for every worker unless a race or comparison assigns another model per arm.
 
 ### 4. Validate
 
@@ -27,7 +51,7 @@ Every real slug written must be in the detected set. `inherit-parent` and `auto`
 
 ### 5. Write the rule
 
-Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true` and one line per role, using the same labels poteto-mode uses. Overwrite the whole file so re-runs stay idempotent. Shape:
+Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true`, one `# budget` line, and one line per role, using the same labels poteto-mode uses. The `# budget` line records the label you chose and its target effort, so a re-run can show it. Overwrite the whole file so re-runs stay idempotent. Shape:
 
 ```
 ---
@@ -36,6 +60,7 @@ alwaysApply: true
 ---
 # pstack model configuration. One line per role. Delete a line to fall back to the skill default.
 # `inherit-parent` or `auto` as a value: the role runs on the parent chat model (omit Task `model`). Alias entries in a panel list still count toward its fan-out.
+# budget: unlimited (max)
 feature, refactoring: grok-4.6-fast-xhigh
 bug-fix: grok-4.6-fast-xhigh
 perf-issue: grok-4.6-fast-xhigh

--- a/pstack/skills/setup-pstack/SKILL.md
+++ b/pstack/skills/setup-pstack/SKILL.md
@@ -26,7 +26,7 @@ The default role-to-model mapping is the rule shape shown in step 5 below. If `~
 - `medium — high reasoning`
 - `small — medium reasoning`
 
-**(b) Apply it.** `unlimited` changes nothing. `large`, `medium`, and `small` set the effort token of every real slug, panel entries included, to `xhigh`, `high`, or `medium`. The effort token is the last token, or the one before a trailing `fast`, on the ladder `max` > `xhigh` > `high` > `medium` > `low`. If the result is not a detected slug, use the same family's detected slug with the highest effort at or below the target, else mark the role as needing a choice. `inherit-parent` and `auto` do not change. So `small` turns `claude-fable-5-1-thinking-max` into `claude-fable-5-1-thinking-medium`, and `grok-4.6-fast-xhigh` into `cursor-grok-4.6-medium-fast` when only that form is detected. On a re-run, rebuild from the defaults, keep any role you changed by family or list, and apply the budget to all of it.
+**(b) Apply it.** Build the working table from the skill defaults, and on a re-run keep any role you changed by family, list, or alias (`inherit-parent`, `auto`). `unlimited` leaves every effort as in that table. `large`, `medium`, and `small` set the effort token of every real slug, panel entries included, to `xhigh`, `high`, or `medium`. The effort token is the last token, or the one before a trailing `fast`, on the ladder `max` > `xhigh` > `high` > `medium` > `low`. If the result is not a detected slug, use the same family's detected slug with the highest effort at or below the target, else mark the role as needing a choice. `inherit-parent` and `auto` do not change. So `small` turns `claude-fable-5-1-thinking-max` into `claude-fable-5-1-thinking-medium`, and `grok-4.6-fast-xhigh` into `cursor-grok-4.6-medium-fast` when only that form is detected.
 
 **(c) Show the roles and confirm.** Show every role with its model, marking any real slug not in the detected set as needing a choice. Ask whether to accept as-is or change specific roles, offering the detected models plus `inherit-parent` and `auto` (both mean: this role runs on the parent chat model, which is how Auto users stay on Auto) as the options. Prefer AskQuestion over free text. For panel roles (arena runners, architect runners, interrogate reviewers) the value is a list, and one subagent runs per entry, alias entries included, so the list length sets the count. `arena cross-judge pool` is also a list, but Arena selects one value from it whose model family differs from the parent's when possible. `swarm workers` is the default model for every worker unless a race or comparison assigns another model per arm.
 
@@ -36,7 +36,7 @@ Every real slug written must be in the detected set. `inherit-parent` and `auto`
 
 ### 5. Write the rule
 
-Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true`, a `# budget` line, and one line per role, using the same labels poteto-mode uses. Overwrite the whole file so re-runs stay idempotent. Shape:
+Write `~/.cursor/rules/pstack-models.mdc` with `alwaysApply: true`, a `# budget` line with the chosen label and its target effort, and one line per role, using the same labels poteto-mode uses. Overwrite the whole file so re-runs stay idempotent. Shape:
 
 ```
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Every `/setup-pstack` default sits at `max` or `xhigh`. Lowering the spend meant changing each role by hand. Step 3 now asks for a budget first and rewrites the whole table to it. The per-role confirm follows as before.

## Scope

- `pstack/skills/setup-pstack/SKILL.md`. Step 3 has three parts. (a) Ask for a budget with AskQuestion, labels `unlimited — keep max`, `large — xhigh reasoning`, `medium — high reasoning`, `small — medium reasoning`. (b) Build the working table from the skill defaults on every run, and on a re-run keep roles changed by family, list, or alias. `unlimited` leaves every effort as in that table. The other three set the effort token of every real slug, panel entries included, to `xhigh`, `high`, or `medium`. A result that is not detected falls to the same family's highest detected effort at or below the target, else the role is marked as needing a choice. `inherit-parent` and `auto` do not change. (c) Show the roles and confirm, unchanged. Step 2 reads the `# budget` line. Step 5 writes it with the chosen label and target effort, `# budget: unlimited (max)` in the template. The description gains "at what reasoning budget" and the trigger "pstack budget".
- `pstack/README.md` and `pstack/docs/guide/01-setup.md`. One sentence each mentions the budget.
- `plugin.json` stays at 0.15.2. Playbook defaults are unchanged.

## Bugbot

Three findings on 5a453d3, all kept, all fixed in ce30f2c with no added paragraphs. Unlimited re-run: the rebuild now comes first in (b). Alias carry-over: named in the same sentence. Budget line: step 5 names the chosen label and target effort.

## Blast Radius

Prose only. One extra question at the start of step 3. `unlimited` gives today's table. Existing `pstack-models.mdc` files stay valid. Consumer skills read role lines only.

## Verification

- Step 3 is 13 lines including heading and blanks, with the four labels and the remap rule.
- Dry walkthrough with a throwaway script over this session's Task allow-list. `small` turns `claude-fable-5-1-thinking-max` into `claude-fable-5-1-thinking-medium` and `grok-4.6-fast-xhigh` into `cursor-grok-4.6-medium-fast`. `unlimited` leaves every default as is. `inherit-parent` never changes.
- `node scripts/validate-plugins.mjs` passes. `plugin.json` reports 0.15.2. The diff against main is three markdown files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-803ce3ae-d18c-5dae-848d-ea5c38225a19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-803ce3ae-d18c-5dae-848d-ea5c38225a19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

